### PR TITLE
add the ability to create hdfs symlinks

### DIFF
--- a/snakebite/client.py
+++ b/snakebite/client.py
@@ -372,6 +372,31 @@ class Client(object):
         response = self.service.rename(request)
         return {"path": path, "result": response.result}
 
+    def symlink(self, path, dst):
+        ''' Create a symbolic link pointing at a file or directory
+
+        :param path: The existing path
+        :type path: string
+        :param dest: The path of the symlink
+        :type dst: string
+        '''
+
+        if not isinstance(path, str):
+            raise InvalidInputException("Path should be a string")
+        if not dst:
+            raise InvalidInputException("symlink: no destination given")
+
+        if not dst.startswith("/"):
+            dst = self._join_user_path(dst)
+
+        request = client_proto.CreateSymlinkRequestProto()
+        request.target = path
+        request.link = dst
+        request.dirPerm.perm = 0644
+        request.createParent = False
+
+        self.service.createSymlink(request)
+
     def delete(self, paths, recurse=False):
         ''' Delete paths
 

--- a/snakebite/commandlineparser.py
+++ b/snakebite/commandlineparser.py
@@ -462,6 +462,12 @@ class CommandLineParser(object):
         for line in format_results(result, json_output=self.args.json):
             print line
 
+    @command(args="path dst", descr="create a link at destination pointing at another path", req_args=['src dst'])
+    def symlink(self):
+        path = self.args.src_dest[0]
+        dst = self.args.src_dest[1]
+        self.client.symlink(path, dst)
+
     @command(args="[paths]", descr="remove paths", allowed_opts=["R"], req_args=['dir [dirs]'])
     def rm(self):
         result = self.client.delete(self.args.dir, recurse=self.args.recurse)

--- a/test/symlink_test.py
+++ b/test/symlink_test.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2013 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+from snakebite.errors import FileNotFoundException
+from snakebite.errors import InvalidInputException
+from minicluster_testbase import MiniClusterTestBase
+
+
+class SymlinkTest(MiniClusterTestBase):
+    def test_create_symlink(self):
+        self.client.symlink('/zerofile', '/zerofile2')
+        file_result = list(self.client.ls(['/zerofile']))
+        self.assertEqual(len(file_result), 1)
+        link_result = list(self.client.ls(['/zerofile2']))
+        self.assertEqual(len(link_result), 1)
+
+    def test_create_symlink_dir(self):
+        self.client.symlink('/dir2', '/dir2link')
+        path_result = list(self.client.ls(['/dir2']))
+        self.assertEqual(len(path_result), 1)
+        self.assertTrue('/dir2/dir3' in [node['path'] for node in path_result])
+        link_result = list(self.client.ls(['/dir2link']))
+        self.assertEqual(len(link_result), 1)
+        self.assertTrue('/dir2/dir3' in [node['path'] for node in link_result])


### PR DESCRIPTION
I wrote this PR before I realized that in most versions of hdfs (pre-2.1.0, according to [HADOOP-8040])(https://issues.apache.org/jira/browse/HADOOP-8040), _reading_ via symlinks is not supported. So while creating symlinks seems to work fine, the tests fail because the namenode throws an `UnresolvedPathException` when you try to `ls` the symlink or do anything useful with it.

I realize that makes this feature next-to-useless, but since I already wrote it I figured I'd send it over just in case you wanted the code (it should work fine with cdh5, I figure). Feel free to close this PR if you don't. 
