### PR TITLE
debian: Build only for Python 2.6+

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Priority: extra
 Maintainer: Wouter de Bie <wouter@spotify.com>
 Build-Depends: python (>= 2.6.6-3~), debhelper (>= 8), python-unittest2, python-protobuf, hadoop-client, hadoop-mapreduce, oracle-java6-jre
 Standards-Version: 3.9.3
+X-Python-Version: >= 2.6
 
 Package: snakebite
 Architecture: all


### PR DESCRIPTION
Without this older systems, like Debian Squeeze, build the package for
python2.5, failing then byte-code compilation post-install step because
of the with-statements.
