### PR TITLE
Fix use_trash missing in external configs

### DIFF
--- a/snakebite/client.py
+++ b/snakebite/client.py
@@ -1320,6 +1320,5 @@ class AutoConfigClient(HAClient):
     '''
     def __init__(self, hadoop_version=Namenode.DEFAULT_VERSION):
         configs = HDFSConfig.get_external_config()
-        nns = [Namenode(c['namenode'], c['port'], hadoop_version, c['use_trash']) for c in configs]
-        use_trash = any([c['use_trash'] for c in configs])
-        super(AutoConfigClient, self).__init__(nns, use_trash)
+        nns = [Namenode(c['namenode'], c['port'], hadoop_version) for c in configs]
+        super(AutoConfigClient, self).__init__(nns, HDFSConfig.use_trash)

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -5,6 +5,7 @@ import time
 import os.path
 import snakebite
 from snakebite.config import HDFSConfig
+from snakebite.client import AutoConfigClient
 from mock import patch, mock_open
 
 class ConfigTest(unittest2.TestCase):
@@ -101,3 +102,19 @@ class ConfigTest(unittest2.TestCase):
 
         self._verify_hdfs_noport_settings(config)
         self.assertTrue(HDFSConfig.use_trash)
+
+    @patch('os.environ.get')
+    def test_autoconfig_client_trash_true(self, environ_get):
+        environ_get.return_value = False
+        HDFSConfig.core_try_paths = (self.get_config_path('ha-core-site.xml'),)
+        HDFSConfig.hdfs_try_paths = (self.get_config_path('ha-noport-trash-hdfs-site.xml'),)
+        client = AutoConfigClient()
+        self.assertTrue(client.use_trash)
+
+    @patch('os.environ.get')
+    def test_autoconfig_client_trash_false(self, environ_get):
+        environ_get.return_value = False
+        HDFSConfig.core_try_paths = (self.get_config_path('ha-core-site.xml'),)
+        HDFSConfig.hdfs_try_paths = (self.get_config_path('ha-noport-hdfs-site.xml'),)
+        client = AutoConfigClient()
+        self.assertFalse(client.use_trash)


### PR DESCRIPTION
Change-Id: I0240155dc9cd5d37454b96212b5d631b038c2b18
