### PR TITLE
Add effective_user support for snakebite.client

### DIFF
--- a/snakebite/service.py
+++ b/snakebite/service.py
@@ -19,13 +19,13 @@ import google.protobuf.service as service
 
 class RpcService(object):
 
-    def __init__(self, service_stub_class, port, host, hadoop_version):
+    def __init__(self, service_stub_class, port, host, hadoop_version, effective_user=None):
         self.service_stub_class = service_stub_class
         self.port = port
         self.host = host
 
         # Setup the RPC channel
-        self.channel = SocketRpcChannel(host=self.host, port=self.port, version=hadoop_version)
+        self.channel = SocketRpcChannel(host=self.host, port=self.port, version=hadoop_version, effective_user=effective_user)
         self.service = self.service_stub_class(self.channel)
 
         # go through service_stub methods and add a wrapper function to

--- a/test/effective_user_test.py
+++ b/test/effective_user_test.py
@@ -1,0 +1,29 @@
+from minicluster_testbase import MiniClusterTestBase
+from snakebite.client import Client
+import os
+
+class EffectiveUserTest(MiniClusterTestBase):
+    ERR_MSG_TOUCH = "org.apache.hadoop.security.AccessControlException\nPermission denied: user=__foobar"
+    ERR_MSG_STAT = "`/foobar2': No such file or directory"
+
+    VALID_FILE = '/foobar'
+    INVALID_FILE = '/foobar2'
+
+    def setUp(self):
+        self.custom_client = Client(self.cluster.host, self.cluster.port)
+        self.custom_foobar_client = Client(host=self.cluster.host,
+                                           port=self.cluster.port,
+                                           effective_user='__foobar')
+
+    def test_touch(self):
+        print tuple(self.custom_client.touchz([self.VALID_FILE]))
+        try:
+            tuple(self.custom_foobar_client.touchz([self.INVALID_FILE]))
+	except Exception, e:
+            self.assertTrue(e.message.startswith(self.ERR_MSG_TOUCH))
+
+        self.custom_client.stat([self.VALID_FILE])
+        try:
+            self.custom_client.stat([self.INVALID_FILE])
+        except Exception, e:
+            self.assertEquals(e.message, self.ERR_MSG_STAT)


### PR DESCRIPTION
Add parameter to support effective_user from client all the way to the
channel. It is now possible to overwrite local user with given user. If
there's no user specified we keep old behavior - use user that executed
snakebite as the effective user.
Effective user is the user that will make the actual changes on the
HDFS.
