### PR TITLE
Fixes bug with HA client in multi threading environments

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,17 @@
 snakebite (2.4.0) unstable; urgency=low
 
+  Fixes bug with HA client in multi threading environments
+
+  HAClient would wrap Client methods with HA functionality, but did
+  this in the constructor. This caused wrapped methods to be wrapped
+  again when client.py was included multiple times.
+  This functionality has been moved to a classmethod that only
+  is called once on module load time.
+
+ -- Wouter de Bie <wouter@spotify.com>  Tue, 13 May 2014 12:01:12 +0000
+
+snakebite (2.4.0) unstable; urgency=low
+
   Add effective_user support for snakebite.client
 
   Add parameter to support effective_user from client all the way to the

--- a/snakebite/version.py
+++ b/snakebite/version.py
@@ -1,4 +1,4 @@
-VERSION = "2.4.0"
+VERSION = "2.4.1"
 
 
 def version():

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -1,0 +1,11 @@
+import unittest2
+import inspect
+
+from snakebite.client import HAClient
+
+class ClientTest(unittest2.TestCase):
+    def test_wrapped_methods(self):
+        public_methods = [(name, method) for name, method in inspect.getmembers(HAClient, inspect.ismethod) if not name.startswith("_")]
+        self.assertGreater(len(public_methods), 0)
+        wrapped_methods = [str(method) for name, method in public_methods if ".wrapped" in str(method)]
+        self.assertEqual(len(public_methods), len(wrapped_methods))


### PR DESCRIPTION
HAClient would wrap Client methods with HA functionality, but did
this in the constructor. This caused wrapped methods to be wrapped
again when client.py was included multiple times.
This functionality has been moved to a classmethod that only
is called once on module load time.
