### PR TITLE
Handle errors gracefully (config parse error, empty namenodes list)

### DIFF
--- a/snakebite/client.py
+++ b/snakebite/client.py
@@ -1250,6 +1250,9 @@ class HAClient(Client):
         '''
         self.use_trash = use_trash
         self.effective_user = effective_user
+
+        if not namenodes:
+            raise OutOfNNException("List of namenodes is empty - couldn't create the client")
         self.namenode = self._switch_namenode(namenodes)
         self.namenode.next()
 
@@ -1348,4 +1351,6 @@ class AutoConfigClient(HAClient):
 
         configs = HDFSConfig.get_external_config()
         nns = [Namenode(c['namenode'], c['port'], hadoop_version) for c in configs]
+        if not nns:
+            raise OutOfNNException("Tried and failed to find namenodes - couldn't created the client!")
         super(AutoConfigClient, self).__init__(nns, HDFSConfig.use_trash, effective_user)

--- a/snakebite/config.py
+++ b/snakebite/config.py
@@ -36,7 +36,11 @@ class HDFSConfig(object):
     @staticmethod
     def read_hadoop_config(hdfs_conf_path):
         if os.path.exists(hdfs_conf_path):
-            tree = ET.parse(hdfs_conf_path)
+            try:
+                tree = ET.parse(hdfs_conf_path)
+            except:
+                log.error("Unable to parse %s" % hdfs_conf_path)
+                return
             root = tree.getroot()
             for p in root.findall("./property"):
                 yield p

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -1,11 +1,36 @@
 import unittest2
 import inspect
+from mock import patch
 
-from snakebite.client import HAClient
+from snakebite.client import HAClient, AutoConfigClient
+from snakebite.config import HDFSConfig
+from snakebite.errors import OutOfNNException
 
 class ClientTest(unittest2.TestCase):
+    original_hdfs_try_path = set(HDFSConfig.hdfs_try_paths)
+    original_core_try_path = set(HDFSConfig.core_try_paths)
+
+    def setUp(self):
+        # Make sure HDFSConfig is in vanilla state
+        HDFSConfig.use_trash = False
+        HDFSConfig.hdfs_try_paths = self.original_hdfs_try_path
+        HDFSConfig.core_try_paths = self.original_core_try_path
+
+
     def test_wrapped_methods(self):
         public_methods = [(name, method) for name, method in inspect.getmembers(HAClient, inspect.ismethod) if not name.startswith("_")]
         self.assertGreater(len(public_methods), 0)
         wrapped_methods = [str(method) for name, method in public_methods if ".wrapped" in str(method)]
         self.assertEqual(len(public_methods), len(wrapped_methods))
+
+    def test_empty_namenodes_haclient(self):
+        namenodes = ()
+        self.assertRaises(OutOfNNException, HAClient, namenodes)
+
+    @patch('os.environ.get')
+    def test_empty_namenodes_autoclient(self, environ_get):
+        #Make sure we will find no namenodes:
+        environ_get.return_value = False
+        HDFSConfig.hdfs_try_paths = ()
+        HDFSConfig.core_try_paths = ()
+        self.assertRaises(OutOfNNException, AutoConfigClient)


### PR DESCRIPTION
1. If there's config parse error, catch it and print error message. Don't
   stop the process, just print message.
2. If namenodes list for HAClient is empty throw exception in the
   **init** method, and print a sane error message.
3. If we find no namenodes in AutoConfigClient **init** method throw
   exception with a sane message.
