### PR TITLE
[#73] Add manifest template

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,10 @@
+include scripts/snakebite-completion.bash
+include LICENSE
+include *.rst
+include requirements.txt
+include requirements-dev.txt
+include tox.ini
+recursive-exclude test *
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude *.un~


### PR DESCRIPTION
Add manifest template, explicit list include/exclude files/dirs.
This will make sure that files like bash completion and license are
included in source distribution.
