### PR TITLE
Update Travis jdk from 6 to 7 [#75]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python: 2.7
-jdk: oraclejdk6
+jdk: oraclejdk7
 branches:
     except:
         - gh-pages


### PR DESCRIPTION
In Hadoop 2.x recommended version of java is 7, let's test on travis
using jdk7.
