### PR TITLE
Don't swallow tracebacks when commands fail.

### DIFF
--- a/snakebite/commandlineparser.py
+++ b/snakebite/commandlineparser.py
@@ -43,15 +43,16 @@ def print_error_exit(msg, fd=sys.stderr):
 def print_info(msg, fd=sys.stderr):
     print >> fd, "Info: %s" % msg
 
-def exitError(error):
-    if isinstance(error, FileNotFoundException) or \
-       isinstance(error, DirectoryException) or \
-       isinstance(error, FileException):
-        print str(error)
-    elif isinstance(error, RequestError):
-        print "Request error: %s" % str(error)
+def exitError(exc_info):
+    exc_type, exc_value, exc_traceback = exc_info
+    if isinstance(
+        exc_value, (FileNotFoundException, DirectoryException, FileException),
+    ):
+        print str(exc_value)
+    elif isinstance(exc_value, RequestError):
+        print "Request error: %s" % str(exc_value)
     else:
-        raise error
+        raise exc_type, exc_value, exc_traceback
     sys.exit(-1)
 
 
@@ -448,8 +449,8 @@ class CommandLineParser(object):
             sys.exit(-1)
         try:
             return Commands.methods[self.cmd]['method'](self)
-        except Exception, e:
-            exitError(e)
+        except Exception:
+            exitError(sys.exc_info())
 
     def command(args="", descr="", allowed_opts="", visible=True, req_args=None):
         def wrap(f):
@@ -522,8 +523,8 @@ class CommandLineParser(object):
             mods = self.client.chown(self.args.dir, owner, recurse=self.args.recurse)
             for line in format_results(mods, json_output=self.args.json):
                 print line
-        except FileNotFoundException, e:
-            exitError(e)
+        except FileNotFoundException:
+            exitError(sys.exc_info())
 
     @command(args="<mode> [paths]", descr="change file mode (octal)", allowed_opts=["R"], req_args=['(int) arg', 'dir [dirs]'])
     def chmod(self):


### PR DESCRIPTION
This propagates tracebacks when commands fail.

The first command I ran was `snakebite ls hdfs://somenamenode`, which before this change produced:

```
Traceback (most recent call last):
  File "bin/snakebite", line 38, in <module>
    SnakebiteCli()
  File "bin/snakebite", line 29, in __init__
    clparser.execute()
  File "/Users/Julian/Development/snakebite/snakebite/commandlineparser.py", line 452, in execute
    exitError(e)
  File "/Users/Julian/Development/snakebite/snakebite/commandlineparser.py", line 54, in exitError
    raise error
IndexError: string index out of range
```

which now produces the slightly more helpful:

```
Traceback (most recent call last):
  File "bin/snakebite", line 38, in <module>
    SnakebiteCli()
  File "bin/snakebite", line 29, in __init__
    clparser.execute()
  File "/Users/Julian/Development/snakebite/snakebite/commandlineparser.py", line 453, in execute
    exitError(sys.exc_info())
  File "/Users/Julian/Development/snakebite/snakebite/commandlineparser.py", line 451, in execute
    return Commands.methods[self.cmd]['method'](self)
  File "/Users/Julian/Development/snakebite/snakebite/commandlineparser.py", line 483, in ls
    for line in self._listing():
  File "/Users/Julian/Development/snakebite/snakebite/commandlineparser.py", line 504, in _listing
    summary=self.args.summary):
  File "/Users/Julian/Development/snakebite/snakebite/formatter.py", line 91, in format_listing
    node = listing.next()
  File "/Users/Julian/Development/snakebite/snakebite/client.py", line 1323, in wrapped
    yield results.next()
  File "/Users/Julian/Development/snakebite/snakebite/client.py", line 139, in ls
    recurse=recurse):
  File "/Users/Julian/Development/snakebite/snakebite/client.py", line 1078, in _find_items
    fileinfo = self._get_file_info(path)
  File "/Users/Julian/Development/snakebite/snakebite/client.py", line 1208, in _get_file_info
    return self.service.getFileInfo(request)
  File "/Users/Julian/Development/snakebite/snakebite/service.py", line 35, in <lambda>
    rpc = lambda request, service=self, method=method.name: service.call(service_stub_class.__dict__[method], request)
  File "/Users/Julian/Development/snakebite/snakebite/service.py", line 41, in call
    return method(self.service, controller, request)
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/google/protobuf/service_reflection.py", line 267, in <lambda>
    self._StubMethod(inst, method, rpc_controller, request, callback))
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/google/protobuf/service_reflection.py", line 284, in _StubMethod
    method_descriptor.output_type._concrete_class, callback)
  File "/Users/Julian/Development/snakebite/snakebite/channel.py", line 414, in CallMethod
    return self.parse_response(byte_stream, response_class)
  File "/Users/Julian/Development/snakebite/snakebite/channel.py", line 367, in parse_response
    (header_len, header_bytes) = get_delimited_message_bytes(byte_stream)
  File "/Users/Julian/Development/snakebite/snakebite/channel.py", line 88, in get_delimited_message_bytes
    (length, pos) = decoder._DecodeVarint32(byte_stream.read(nr), 0)
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/google/protobuf/internal/decoder.py", line 116, in DecodeVarint
    b = local_ord(buffer[pos])
IndexError: string index out of range
```

which at least lets me know what the `IndexError` is in reference to.
