### PR TITLE
Use multi dimension from Tox 1.8.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,6 @@ nose
 unittest2
 mock
 virtualenv>=1.11.2
-tox>=1.7.2
+tox>=1.8.0
 sphinx
 fig

--- a/tox.ini
+++ b/tox.ini
@@ -1,33 +1,17 @@
 [tox]
-envlist = py26-cdh,py27-cdh,py26-hdp,py27-hdp
+envlist = {py26,py27}-{cdh,hdp}
 
 [testenv]
-usedevelop=True
+usedevelop = True
 deps = -rrequirements-dev.txt
+basepython =
+  py26: python2.6
+  py27: python2.7
+setenv =
+  cdh: HADOOP_DISTRO=cdh
+  cdh: HADOOP_HOME=/tmp/hadoop-cdh
+  hdp: HADOOP_DISTRO=hdp
+  hdp: HADOOP_HOME=/tmp/hadoop-hdp
 commands =
-    {toxinidir}/scripts/ci/setup_env.sh
-    {toxinidir}/scripts/ci/run_tests.sh []
-
-[testenv:py26-cdh]
-basepython=python2.6
-setenv=
-    HADOOP_DISTRO=cdh
-    HADOOP_HOME=/tmp/hadoop-cdh
-
-[testenv:py26-hdp]
-basepython=python2.6
-setenv=
-    HADOOP_DISTRO=hdp
-    HADOOP_HOME=/tmp/hadoop-hdp
-
-[testenv:py27-cdh]
-basepython=python2.7
-setenv=
-    HADOOP_DISTRO=cdh
-    HADOOP_HOME=/tmp/hadoop-cdh
-
-[testenv:py27-hdp]
-basepython=python2.7
-setenv=
-    HADOOP_DISTRO=hdp
-    HADOOP_HOME=/tmp/hadoop-hdp
+  {toxinidir}/scripts/ci/setup_env.sh
+  {toxinidir}/scripts/ci/run_tests.sh []


### PR DESCRIPTION
- update tox from 1.7.2 to 1.8.0
- small style change - add spaces around = in tox.ini
- rewrite tox.ini with support for multi dimension environment
  specification - less repetition

Closes #83
