### PR TITLE
[#101] Add block size parameter for put operation on minicluster

### DIFF
--- a/snakebite/minicluster.py
+++ b/snakebite/minicluster.py
@@ -92,8 +92,9 @@ class MiniCluster(object):
         src = "%s%s" % (self._testfiles_path, src)
         return self._runCmd([self._hadoop_cmd, 'fs', '-put', src, self._full_hdfs_path(dst)])
 
-    def put_subprocess(self, src, dst):  # This is used for testing with large files.
-        cmd = [self._hadoop_cmd, 'fs', '-put', src, self._full_hdfs_path(dst)]
+    def put_subprocess(self, src, dst, block_size=134217728):  # This is used for testing with large files.
+        block_size_flag = "-Ddfs.block.size=%s" % str(block_size)
+        cmd = [self._hadoop_cmd, 'fs', block_size_flag, '-put', src, self._full_hdfs_path(dst)]
         return subprocess.Popen(cmd, bufsize=0, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
 
     def ls(self, src, extra_args=[]):


### PR DESCRIPTION
In some tests snakebite depends on number of test data blocks, original
tests were writing big amount of data to get required number of blocks.
Make it possible to change default block 128MB, it will allow to much
easier change number of data file blocks and hopefully increase test
speed.

Closes #101
