### PR TITLE
Catch socket error when server is down / not responding

### DIFF
--- a/snakebite/client.py
+++ b/snakebite/client.py
@@ -1289,7 +1289,7 @@ class HAClient(Client):
 
     def __handle_socket_error(self, exception):
         log.debug("Request failed with %s" % exception)
-        if exception.errno == errno.ECONNREFUSED:
+        if exception.errno in (errno.ECONNREFUSED, errno.EHOSTUNREACH):
             # if NN is down or machine is not available, pass it:
             pass
         elif isinstance(exception, socket.timeout):

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -28,6 +28,15 @@ class ClientTest(unittest2.TestCase):
         cat_result_gen = ha_client.cat(ha_client, ['foobar'])
         self.assertRaises(OutOfNNException, all, cat_result_gen)
 
+    def test_ha_client_ehostunreach_socket_error(self):
+        e = socket.error
+        e.errno = errno.EHOSTUNREACH
+        mocked_client_cat = Mock(side_effect=e)
+        ha_client = HAClient([Namenode("foo"), Namenode("bar")])
+        ha_client.cat = HAClient._ha_gen_method(mocked_client_cat)
+        cat_result_gen = ha_client.cat(ha_client, ['foobar'])
+        self.assertRaises(OutOfNNException, all, cat_result_gen)
+
     def test_ha_client_socket_timeout(self):
         e = socket.timeout
         mocked_client_cat = Mock(side_effect=e)


### PR DESCRIPTION
When the NN is not responding, it throws error(113, 'No route to host'). We
should capture that and switch to next available NN.
