### PR TITLE
Issue 113 - Snakebite unable to parse core-site.xml in EMR

### DIFF
--- a/snakebite/config.py
+++ b/snakebite/config.py
@@ -50,7 +50,9 @@ class HDFSConfig(object):
     def read_core_config(cls, core_site_path):
         config = []
         for property in cls.read_hadoop_config(core_site_path):
-            if property.findall('name')[0].text == 'fs.defaultFS':
+
+            # fs.default.name is the key name for the file system on EMR clusters
+            if property.findall('name')[0].text in ('fs.defaultFS', 'fs.default.name'):
                 parse_result = urlparse(property.findall('value')[0].text)
                 log.debug("Got namenode '%s' from %s" % (parse_result.geturl(), core_site_path))
 

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -53,6 +53,14 @@ class ConfigTest(unittest2.TestCase):
         self.assertEquals(8020, config[0]['port'])
         self.assertFalse(HDFSConfig.use_trash)
 
+    def test_read_core_config_emr(self):
+        core_site_path = self.get_config_path('emr-core-site.xml')
+        config = HDFSConfig.read_core_config(core_site_path)
+        self.assertEquals(len(config), 1)
+        self.assertEquals('testha', config[0]['namenode'])
+        self.assertEquals(8020, config[0]['port'])
+        self.assertFalse(HDFSConfig.use_trash)
+
     @patch('os.environ.get')
     def test_read_config_ha_with_ports(self, environ_get):
         environ_get.return_value = False

--- a/test/testconfig/conf/emr-core-site.xml
+++ b/test/testconfig/conf/emr-core-site.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>fs.default.name</name>
+    <value>hdfs://testha</value>
+  </property>
+</configuration>


### PR DESCRIPTION
This is to accommodate snakebite to work on EMR cluster. All tests ran successfully. Added to test to see if the config is read correctly on config.py.