### PR TITLE
Fix #109 - touchz support for multiple items

### DIFF
--- a/snakebite/client.py
+++ b/snakebite/client.py
@@ -1080,7 +1080,10 @@ class Client(object):
                     raise FileNotFoundException("`%s': No such file or directory" % path)
                 elif not fileinfo and check_nonexistence:
                     yield processor(path, None)
-                    return
+                    continue
+                elif fileinfo and check_nonexistence:
+                    yield {"path": path, "result": False, "error": "File already exists"}
+                    continue
 
                 if (include_toplevel and fileinfo) or not self._is_dir(fileinfo.fs):
                     # Construct the full path before processing
@@ -1204,7 +1207,6 @@ class Client(object):
     def _get_file_info(self, path):
         request = client_proto.GetFileInfoRequestProto()
         request.src = path
-
         return self.service.getFileInfo(request)
 
     def _join_user_path(self, path):

--- a/test/touchz_test.py
+++ b/test/touchz_test.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2014 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+from snakebite.errors import DirectoryException, FileException
+from minicluster_testbase import MiniClusterTestBase
+
+class TouchZTest(MiniClusterTestBase):
+    counter = 0
+
+    @classmethod
+    def get_fresh_filename(cls, prefix="/"):
+        cls.counter+=1
+        return "%stouchz_foobar%d" % (prefix, cls.counter) 
+
+    def test_touchz_single(self):
+        f1 = self.get_fresh_filename()
+        result = all([ r['result'] for r in self.client.touchz([f1]) ])
+        self.assertTrue(result)
+        self.assertTrue(self.cluster.is_zero_bytes_file(f1))
+
+    def test_touchz_multiple(self):
+        f1, f2, f3 = self.get_fresh_filename(), self.get_fresh_filename(), self.get_fresh_filename()
+        result = all([ r['result'] for r in
+            self.client.touchz([f1, f2, f3]) ])
+        self.assertTrue(result)
+        self.assertTrue(self.cluster.is_zero_bytes_file(f1))
+        self.assertTrue(self.cluster.is_zero_bytes_file(f2))
+        self.assertTrue(self.cluster.is_zero_bytes_file(f3))
+
+    def test_touchz_dir_doesnt_exists(self):
+        f1 = self.get_fresh_filename(prefix="/big/data/lake/dir/")
+        self.assertRaises(DirectoryException, all, self.client.touchz([f1]))
+        self.assertFalse(self.cluster.is_zero_bytes_file(f1))
+
+    def test_touchz_file_already_exists(self):
+        f1 = self.get_fresh_filename()
+        result = all([ r['result'] for r in self.client.touchz([f1]) ])
+        self.assertTrue(result)
+        self.assertTrue(self.cluster.is_zero_bytes_file(f1))
+        result = all([ r['result'] for r in self.client.touchz([f1]) ])
+        self.assertFalse(result)


### PR DESCRIPTION
Initial interface supports list as input for touchz, but snakebite only
handled the first _created_ file and then stopped. Add support for
multiple items.
