### PR TITLE
Fix #117 - remove cp, put and copyFromLocal from CLI

### DIFF
--- a/snakebite/commandlineparser.py
+++ b/snakebite/commandlineparser.py
@@ -542,27 +542,11 @@ class CommandLineParser(object):
             for load in file_to_read:
                 print load
 
-    @command(args="path dst", descr="copy local file reference to destination", req_args=['dir [dirs]', 'arg'])
-    def copyFromLocal(self):
-        src = self.args.dir
-        dst = self.args.single_arg
-        result = self.client.copyFromLocal(src, dst)
-        for line in format_results(result, json_output=self.args.json):
-            print line
-
     @command(args="[paths] dst", descr="copy paths to local file system destination", allowed_opts=['checkcrc'], req_args=['dir [dirs]', 'arg'])
     def copyToLocal(self):
         paths = self.args.dir
         dst = self.args.single_arg
         result = self.client.copyToLocal(paths, dst, check_crc=self.args.checkcrc)
-        for line in format_results(result, json_output=self.args.json):
-            print line
-
-    @command(args="[paths] dst", descr="copy files from source to destination", allowed_opts=['checkcrc'], req_args=['dir [dirs]', 'arg'])
-    def cp(self):
-        paths = self.args.dir
-        dst = self.args.single_arg
-        result = self.client.cp(paths, dst, checkcrc=self.args.checkcrc)
         for line in format_results(result, json_output=self.args.json):
             print line
 
@@ -581,14 +565,6 @@ class CommandLineParser(object):
         result = self.client.getmerge(source, dst, newline=self.args.newline)
         for line in format_results(result, json_output=self.args.json):
             print line
-
-    # @command(args="[paths] dst", descr="copy sources from local file system to destination", req_args=['dir [dirs]', 'arg'])
-    # def put(self):
-    #     paths = self.args.dir
-    #     dst = self.args.single_arg
-    #     result = self.client.put(paths, dst)
-    #     for line in format_results(result, json_output=self.args.json):
-    #         print line
 
     @command(args="path", descr="display last kilobyte of the file to stdout", allowed_opts=['f'], req_args=['arg'])
     def tail(self):

--- a/test/commandlineparser_test.py
+++ b/test/commandlineparser_test.py
@@ -454,22 +454,6 @@ class CommandLineParserTest(unittest2.TestCase):
         output = parser.parse('cat -checkcrc dir1 dir2'.split())
         self.assertEqual(output.checkcrc, True)
 
-    def test_copyFromLocal(self):
-        parser = self.parser
-
-        #no dir
-        with self.assertRaises(SystemExit):
-            parser.parse('copyFromLocal'.split())
-
-        #one dir
-        with self.assertRaises(SystemExit):
-            parser.parse('copyFromLocal some_dir'.split())
-
-        #two dirs
-        output = parser.parse('copyFromLocal dir1 dir2'.split())
-        self.assertEqual(output.dir, ['dir1'])
-        self.assertEqual(output.single_arg, 'dir2')
-
     def test_copyToLocal(self):
         parser = self.parser
 
@@ -490,22 +474,6 @@ class CommandLineParserTest(unittest2.TestCase):
         #specific commands
         output = parser.parse('copyToLocal -checkcrc dir1 dir2'.split())
         self.assertEqual(output.checkcrc, True)
-
-    def test_cp(self):
-        parser = self.parser
-
-        #no dir
-        with self.assertRaises(SystemExit):
-            parser.parse('cp'.split())
-
-        #one dir
-        with self.assertRaises(SystemExit):
-            parser.parse('cp some_dir'.split())
-
-        #multiple dirs
-        output = parser.parse('cp dir1 dir2 dir3'.split())
-        self.assertEqual(output.dir, ['dir1', 'dir2'])
-        self.assertEqual(output.single_arg, 'dir3')
 
     def test_get(self):
         parser = self.parser
@@ -546,22 +514,6 @@ class CommandLineParserTest(unittest2.TestCase):
         #multiple dirs
         with self.assertRaises(SystemExit):
             parser.parse('getmerge dir1 dir2 dir3'.split())
-
-    # def test_put(self):
-    #     parser = self.parser
-
-    #     #no dir
-    #     with self.assertRaises(SystemExit):
-    #         parser.parse('put'.split())
-
-    #     #one dir
-    #     with self.assertRaises(SystemExit):
-    #         parser.parse('put some_dir'.split())
-
-    #     #multiple dirs
-    #     output = parser.parse('put dir1 dir2 dir3'.split())
-    #     self.assertEqual(output.dir, ['dir1', 'dir2'])
-    #     self.assertEqual(output.single_arg, 'dir3')
 
     def test_tail(self):
         parser = self.parser


### PR DESCRIPTION
Remove copyFromLocal, cp and put from CLI - these methods are not implemented in
client.
