### PR TITLE
Fix #119 - adjust du output parser to HADOOP-6857

### DIFF
--- a/snakebite/minicluster.py
+++ b/snakebite/minicluster.py
@@ -202,8 +202,17 @@ class MiniCluster(object):
         result = []
         for line in i.split("\n"):
             if line:
-                (length, path) = re.split("\s+", line)
-                result.append({"path": path.replace(base_path, ""), "length": long(length)})
+                fields = re.split("\s+", line)
+                if len(fields) == 3:
+                    (length, space_consumed, path) = re.split("\s+", line)
+                elif len(fields) == 2:
+                    (length, path) = re.split("\s+", line)
+                else:
+                    raise ValueError("Result of du operation should contain 2"
+                                     " or 3 field, but there's %d fields"
+                                     % len(fields))
+                result.append({"path": path.replace(base_path, ""),
+                               "length": long(length)})
         return result
 
     def _transform_count_output(self, i, base_path):


### PR DESCRIPTION
HADOOP-6857 introduced another column (spaceConsumed) in du output.
Since snakebite still outputs only size (length), and path for now we
ignore spaceConsumed - this should change in #120.
