### PR TITLE
Fix #115: test should communicate result only via return code

### DIFF
--- a/snakebite/commandlineparser.py
+++ b/snakebite/commandlineparser.py
@@ -638,7 +638,13 @@ class CommandLineParser(object):
     @command(args="path", descr="test a path", allowed_opts=['d', 'z', 'e'], req_args=['arg'])
     def test(self):
         path = self.args.single_arg
-        if self.client.test(path, exists=self.args.exists, directory=self.args.directory, zero_length=self.args.zero):
+
+        try:
+            result = self.client.test(path, exists=self.args.exists, directory=self.args.directory, zero_length=self.args.zero)
+        except FileNotFoundException:
+            result = False
+
+        if result:
             sys.exit(0)
         else:
             sys.exit(1)


### PR DESCRIPTION
If file for test operation doesn't exist snakebite _prints_ 'XXX: No
such file or directory', which is inconsistent with unix/hdfs test
command behaviour. In this patch make sure that if file doesn't exist
snakebite returns 1 as a command return code.