### PR TITLE
Stricten version dependency on protobuf to >2.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 argparse
-protobuf>=2.4.1
+protobuf>2.4.1


### PR DESCRIPTION
It seems like `setup.py` has the dependency `protobuf>2.4.1` specified
in `install_requires`.

Previously, when I ran `python setup.py test` (preceeded by a `sudo pip
install -r requirements.txt`), I got this as output:

    ~/spotify/repos/snakebite master
    ❯ python setup.py test
    running test
    Traceback (most recent call last):
      File "setup.py", line 76, in <module>
        cmdclass={'test': Tox}
      File "/usr/lib/python2.7/distutils/core.py", line 152, in setup
        dist.run_commands()
      File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
        self.run_command(cmd)
      File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
        cmd_obj.run()
      File "/usr/lib/python2.7/dist-packages/setuptools/command/test.py", line 127, in run
        self.distribution.fetch_build_eggs(self.distribution.install_requires)
      File "/usr/lib/python2.7/dist-packages/setuptools/dist.py", line 245, in fetch_build_eggs
        parse_requirements(requires), installer=self.fetch_build_egg
      File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 588, in resolve
        raise VersionConflict(dist,req) # XXX put more info here
    pkg_resources.VersionConflict: (protobuf 2.4.1 (/usr/lib/python2.7/dist-packages), Requirement.parse('protobuf>2.4.1'))

But after changing requirements.txt it works.