### PR TITLE
FIX: Fix formatting of permissions with sticky bit

### DIFF
--- a/snakebite/formatter.py
+++ b/snakebite/formatter.py
@@ -225,12 +225,17 @@ def _create_count_listing(nodes, human_readable):
         ret.append(templ % (node['length'], node['path']))
     return "\n".join(ret)
 
+def _format_permission(decimal_permissions):
+    """ formats a decimal representation of UNIX-style permissions,
+        removing leading 0 for octal numbers with length > 4,
+        into a string representation """
+    return "{0:04o}".format(decimal_permissions)[-4:]
 
 def format_stat(results, json_output=False):
     ret = results
     # By default snakebite returns permissions in decimal.
     if ret.has_key('permission'):
-        ret['permission'] = oct(ret['permission'])
+        ret['permission'] = _format_permission(ret['permission'])
     if json_output:
         return json.dumps(ret)
     return "\n".join(["%-20s\t%s" % (k, v) for k, v in sorted(ret.iteritems())])

--- a/test/minicluster_testbase.py
+++ b/test/minicluster_testbase.py
@@ -51,6 +51,8 @@ class MiniClusterTestBase(unittest2.TestCase):
             cls.cluster.put("/zerofile", "/bar/foo/baz/qux")
             cls.cluster.put("/log", "/")
 
+            cls.cluster.mkdir("/sticky_dir")
+
     @classmethod
     def tearDownClass(cls):
         if cls.cluster:


### PR DESCRIPTION
Snakebite always prepended a leading 0 to permissions when using the 'stat'
command. This led to invalid permissions being returned. For example in cases
like "1777" it returned "01777". This is supposed to fix this case.