### PR TITLE
Fix #148 - make sure single_arg is used for CL parsing

### DIFF
--- a/snakebite/commandlineparser.py
+++ b/snakebite/commandlineparser.py
@@ -251,7 +251,7 @@ class CommandLineParser(object):
         for path in self.__get_all_directories():
             if path.startswith('hdfs://'):
                 parse_result = urlparse(path)
-                if path in self.args.dir:
+                if 'dir' in self.args and path in self.args.dir:
                     self.args.dir.remove(path)
                     self.args.dir.append(parse_result.path)
                 else:
@@ -357,13 +357,19 @@ class CommandLineParser(object):
             print_error_exit("Config retrieved from %s is corrupted! Remove it!" % path)
 
     def __get_all_directories(self):
-        if self.args and 'dir' in self.args:
-            dirs_to_check = list(self.args.dir)
-            if self.args.command == 'mv':
+        dirs_to_check = []
+
+        # append single_arg for operations that use single_arg
+        # as HDFS path
+        if self.args.command in ('mv', 'test', 'tail'):
+            if self.args.single_arg is not None:
                 dirs_to_check.append(self.args.single_arg)
-            return dirs_to_check
-        else:
-            return ()
+
+        # add dirs if they exists:
+        if self.args and 'dir' in self.args:
+            dirs_to_check += self.args.dir
+
+        return dirs_to_check
 
     def _read_config_cl(self):
         ''' Check if any directory arguments contain hdfs://'''

--- a/test/commandlineparser_test.py
+++ b/test/commandlineparser_test.py
@@ -763,6 +763,28 @@ class CommandLineParserInternalConfigTest(unittest2.TestCase):
         self.assertIn("/user/rav2", self.parser.args.dir)
         self.assertEqual(self.parser.args.single_arg, "/user/rav3")
 
+    def test_cl_config_test_single_arg_hdfs_paths(self):
+        self.parser.args = MockParseArgs(single_arg="hdfs://foobar:50070/user/rav3",
+                                         command="test")
+        self.parser.init()
+        self.assert_namenode_spec("foobar", 50070)
+        self.assertEqual(self.parser.args.single_arg, "/user/rav3")
+
+    def test_cl_config_tail_single_arg_hdfs_paths(self):
+        self.parser.args = MockParseArgs(single_arg="hdfs://foobar:50070/user/rav3",
+                                         command="tail")
+        self.parser.init()
+        self.assert_namenode_spec("foobar", 50070)
+        self.assertEqual(self.parser.args.single_arg, "/user/rav3")
+
+    def test_cl_config_mv_single_arg_hdfs_paths(self):
+        self.parser.args = MockParseArgs(single_arg="hdfs://foobar:50070/user/rav3",
+                                         command="mv")
+        self.parser.init()
+        self.assert_namenode_spec("foobar", 50070)
+        self.assertEqual(self.parser.args.single_arg, "/user/rav3")
+
+
     import snakebite.config
     @patch.object(snakebite.config.HDFSConfig, 'get_external_config')
     @patch("snakebite.commandlineparser.CommandLineParser._read_config_snakebiterc", return_value=None)


### PR DESCRIPTION
For operations: mv, test and tail - single_arg is used to carry hdfs
path, and there's no extra dirs for this operations thus CL parsing
method skipped single_args - in this commit make sure single_arg is
always included for this operations.