### PR TITLE
Handles broken pipe errors in snakebite commands

### DIFF
--- a/snakebite/commandlineparser.py
+++ b/snakebite/commandlineparser.py
@@ -14,6 +14,7 @@
 # the License.
 
 import argparse
+import errno
 import sys
 import os
 import pwd
@@ -450,6 +451,9 @@ class CommandLineParser(object):
             sys.exit(-1)
         try:
             return Commands.methods[self.cmd]['method'](self)
+        except IOError as e:
+            if e.errno != errno.EPIPE:
+                exitError(sys.exc_info())
         except Exception:
             exitError(sys.exc_info())
 


### PR DESCRIPTION
Piping the output of a snakebite command like text or cat to head results in a
broken pipe error when head closes the output pipe that snakebite was using.
This catches and ignores the exception, saving the user from a meaningless stack
trace after a successful series of commands.