### PR TITLE
Add SASL authentication

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 argparse
 protobuf>2.4.1
+sasl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 argparse
 protobuf>2.4.1
 sasl
+python-krbV

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,9 @@ class Tox(TestCommand):
 
 install_requires = [
     'protobuf>2.4.1',
-    'argparse']
+    'argparse',
+    'sasl',
+    'python-krbV']
 
 tests_require = [
     'tox',

--- a/snakebite/channel.py
+++ b/snakebite/channel.py
@@ -60,6 +60,10 @@ from snakebite.crc32c import crc
 import google.protobuf.internal.encoder as encoder
 import google.protobuf.internal.decoder as decoder
 
+# SASL
+from snakebite.rpc_sasl import SaslRpcClient
+from snakebite.kerberos import Kerberos
+
 # Module imports
 
 import logger
@@ -173,7 +177,11 @@ class SocketRpcChannel(RpcChannel):
         self.version = version
         self.client_id = str(uuid.uuid4())
         self.use_sasl = use_sasl
-        self.effective_user = effective_user or pwd.getpwuid(os.getuid())[0]
+        if self.use_sasl:
+            kerberos = Kerberos()
+            self.effective_user = effective_user or kerberos.user_principal().name
+        else: 
+            self.effective_user = effective_user or pwd.getpwuid(os.getuid())[0]
 
     def validate_request(self, request):
         '''Validate the client request against the protocol file.'''

--- a/snakebite/channel.py
+++ b/snakebite/channel.py
@@ -156,13 +156,14 @@ class SocketRpcChannel(RpcChannel):
     RPC_HEADER = "hrpc"
     RPC_SERVICE_CLASS = 0x00
     AUTH_PROTOCOL_NONE = 0x00
+    AUTH_PROTOCOL_SASL = 0xDF
     RPC_PROTOCOL_BUFFFER = 0x02
 
 
     '''Socket implementation of an RpcChannel.
     '''
 
-    def __init__(self, host, port, version, effective_user=None):
+    def __init__(self, host, port, version, effective_user=None, use_sasl=False):
         '''SocketRpcChannel to connect to a socket server on a user defined port.
            It possible to define version and effective user for the communication.'''
         self.host = host
@@ -171,6 +172,7 @@ class SocketRpcChannel(RpcChannel):
         self.call_id = -3  # First time (when the connection context is sent, the call_id should be -3, otherwise start with 0 and increment)
         self.version = version
         self.client_id = str(uuid.uuid4())
+        self.use_sasl = use_sasl
         self.effective_user = effective_user or pwd.getpwuid(os.getuid())[0]
 
     def validate_request(self, request):
@@ -214,7 +216,16 @@ class SocketRpcChannel(RpcChannel):
         self.write(self.RPC_HEADER)                             # header
         self.write(struct.pack('B', self.version))              # version
         self.write(struct.pack('B', self.RPC_SERVICE_CLASS))    # RPC service class
-        self.write(struct.pack('B', self.AUTH_PROTOCOL_NONE))   # serialization type (protobuf = 0)
+        if self.use_sasl:
+            self.write(struct.pack('B', self.AUTH_PROTOCOL_SASL))   # serialization type (protobuf = 0xDF)
+        else:
+            self.write(struct.pack('B', self.AUTH_PROTOCOL_NONE))   # serialization type (protobuf = 0)
+
+        if self.use_sasl:
+            sasl = SaslRpcClient(self)
+            sasl_connected = sasl.connect()
+            if not sasl_connected:
+                raise Exception("SASL is configured, but cannot get connected")
 
         rpc_header = self.create_rpc_request_header()
         context = self.create_connection_context()

--- a/snakebite/client.py
+++ b/snakebite/client.py
@@ -1327,7 +1327,7 @@ class HAClient(Client):
                 else:
                     setattr(cls, name, cls._ha_return_method(meth))
 
-    def __init__(self, namenodes, use_trash=False, effective_user=None):
+    def __init__(self, namenodes, use_trash=False, effective_user=None, authentication="simple"):
         '''
         :param namenodes: Set of namenodes for HA setup
         :type namenodes: list
@@ -1338,6 +1338,7 @@ class HAClient(Client):
         '''
         self.use_trash = use_trash
         self.effective_user = effective_user
+        self.use_sasl = True if authentication == "kerberos" else False
 
         if not namenodes:
             raise OutOfNNException("List of namenodes is empty - couldn't create the client")
@@ -1441,4 +1442,4 @@ class AutoConfigClient(HAClient):
         nns = [Namenode(c['namenode'], c['port'], hadoop_version) for c in configs]
         if not nns:
             raise OutOfNNException("Tried and failed to find namenodes - couldn't created the client!")
-        super(AutoConfigClient, self).__init__(nns, HDFSConfig.use_trash, effective_user)
+        super(AutoConfigClient, self).__init__(nns, HDFSConfig.use_trash, effective_user, HDFSConfig.use_sasl)

--- a/snakebite/commandlineparser.py
+++ b/snakebite/commandlineparser.py
@@ -180,6 +180,7 @@ class CommandLineParser(object):
         self._build_parent_parser()
         self._add_subparsers()
         self.namenodes = []
+        self.use_sasl = False
 
     def _build_parent_parser(self):
         #general options
@@ -289,6 +290,7 @@ class CommandLineParser(object):
                     self.namenodes.append(nn)
                 if self.__usetrash_unset():
                     self.args.usetrash = HDFSConfig.use_trash
+                self.use_sasl = HDFSConfig.use_sasl
 
         if len(self.namenodes):
             return
@@ -439,7 +441,7 @@ class CommandLineParser(object):
             use_trash = self.args.usetrash and not self.args.skiptrash
         else:
             use_trash = self.args.usetrash
-        self.client = HAClient(self.namenodes, use_trash)
+        self.client = HAClient(self.namenodes, use_trash, None, self.use_sasl)
 
     def execute(self):
         if self.args.help:

--- a/snakebite/config.py
+++ b/snakebite/config.py
@@ -63,6 +63,12 @@ class HDFSConfig(object):
             if property.findall('name')[0].text == 'fs.trash.interval':
                 cls.use_trash = True
 
+            if property.findall('name')[0].text == 'hadoop.security.authentication':
+                if property.findall('value')[0].text == 'kerberos':
+                    cls.use_sasl = True
+                else:
+                    cls.use_sasl = False
+ 
         return config
 
     @classmethod

--- a/snakebite/config.py
+++ b/snakebite/config.py
@@ -10,6 +10,7 @@ log = logging.getLogger(__name__)
 
 class HDFSConfig(object):
     use_trash = False
+    use_sasl = False
 
     @classmethod
     def get_config_from_env(cls):
@@ -64,6 +65,7 @@ class HDFSConfig(object):
                 cls.use_trash = True
 
             if property.findall('name')[0].text == 'hadoop.security.authentication':
+                log.debug("Got hadoop.security.authentication '%s'" % (property.findall('value')[0].text))
                 if property.findall('value')[0].text == 'kerberos':
                     cls.use_sasl = True
                 else:

--- a/snakebite/kerberos.py
+++ b/snakebite/kerberos.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2015 Bolke de Bruin
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+'''
+kerberos.py - A very light wrapper around krbV
+
+This package contains a class to read a kerberos principal
+
+May 2015
+
+Bolke de Bruin (bolke@xs4all.nl)
+
+'''
+
+import krbV
+
+class Kerberos:
+    def __init__(self):
+        self.ctx = krbV.default_context()
+        self.ccache = self.ctx.default_ccache()
+
+    def user_principal(self):
+        return self.ccache.principal()
+

--- a/snakebite/rpc_sasl.py
+++ b/snakebite/rpc_sasl.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2015 Bolke de Bruin
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+'''
+rpc_sasl.py - Implementation of SASL on top of Hadoop RPC.
+
+This package contains a class providing a SASL authentication implementation
+using Hadoop RPC as a transport. It was inspired the Hadoop Java classes.
+
+May 2015
+
+Bolke de Bruin (bolke@xs4all.nl)
+
+'''
+
+import struct
+import sasl
+
+from snakebite.protobuf.RpcHeader_pb2 import RpcRequestHeaderProto, RpcResponseHeaderProto, RpcSaslProto
+import google.protobuf.internal.encoder as encoder
+
+import logger
+
+# Configure package logging
+log = logger.getLogger(__name__)
+
+def log_protobuf_message(header, message):
+    log.debug("%s:\n\n\033[92m%s\033[0m" % (header, message))
+
+class SaslRpcClient:
+    def __init__(self, sasl_client_factory, mechanism, trans):
+        self.sasl_client_factory = sasl_client_factory
+        self.sasl = None
+        self.mechanism = mechanism
+        self._trans = trans
+
+    def send_sasl_message(self, message):
+        rpcheader = RpcRequestHeaderProto()
+        rpcheader.rpcKind = 2 # RPC_PROTOCOL_BUFFER
+        rpcheader.rpcOp = 0
+        rpcheader.callId = -33 # SASL
+        rpcheader.retryCount = -1
+        rpcheader.clientId = b""
+
+        s_rpcheader = rpcheader.SerializeToString()
+        s_message = message.SerializeToString()
+        
+        header_length = len(s_rpcheader) + encoder._VarintSize(len(s_rpcheader)) + len(s_message) + encoder._VarintSize(len(s_message)) 
+
+        self._trans.write(struct.pack('!I', header_length))
+        self._trans.write_delimited(s_rpcheader)
+        self._trans.write_delimited(s_message)
+
+        log_protobuf_message("Send out", message)
+
+    def recv_sasl_message(self):
+        bytestream = self._trans.recv_rpc_message()
+        sasl_response = self._trans.parse_response(bytestream, RpcSaslProto)
+
+        return sasl_response
+
+    def sasl_connect(self):
+        negotiate = RpcSaslProto()
+        negotiate.state = 1
+        self.send_sasl_message(negotiate)
+
+        self.sasl = self.sasl_client_factory()
+        ret, chosen_mech, initial_response = self.sasl.start("TOKEN,GSSAPI")
+        log.debug("Chosen mech: %s" % chosen_mech)
+        log.debug("Initial response: %s" % initial_response)
+
+        # do while true
+        while True:
+          res = self.recv_sasl_message()
+          # TODO: check mechanisms
+          if res.state == 1:
+            #res_token = b""
+            initiate = RpcSaslProto()
+            initiate.state = 2
+            initiate.token = initial_response
+
+            #auth_method = RpcSaslProto.SaslAuth()
+            auth_method = initiate.auths.add()
+            auth_method.mechanism = "GSSAPI"
+            auth_method.method = "KERBEROS"
+            auth_method.protocol = "hdfs"
+            auth_method.serverId = "master01.paymentslab.int"
+
+            #initiate.auths.append(auth_method) 
+            self.send_sasl_message(initiate)
+            continue
+           
+          if res.state == 3:
+            res_token = self.sasl_evaluate_token(res)
+            response = RpcSaslProto()
+            response.token = res_token
+            response.state = 4
+            self.send_sasl_message(response)
+            continue
+
+          if res.state == 0:
+            return True
+
+    def sasl_evaluate_token(self, sasl_response):
+        ret, response = self.sasl.step(sasl_response.token)
+        if not ret:
+          raise Exception("Bad SASL results: %s" % (self.sasl.getError()))
+
+        return response 
+
+    def select

--- a/snakebite/service.py
+++ b/snakebite/service.py
@@ -19,13 +19,13 @@ import google.protobuf.service as service
 
 class RpcService(object):
 
-    def __init__(self, service_stub_class, port, host, hadoop_version, effective_user=None):
+    def __init__(self, service_stub_class, port, host, hadoop_version, effective_user=None,use_sasl=False):
         self.service_stub_class = service_stub_class
         self.port = port
         self.host = host
 
         # Setup the RPC channel
-        self.channel = SocketRpcChannel(host=self.host, port=self.port, version=hadoop_version, effective_user=effective_user)
+        self.channel = SocketRpcChannel(host=self.host, port=self.port, version=hadoop_version, effective_user=effective_user,use_sasl=use_sasl)
         self.service = self.service_stub_class(self.channel)
 
         # go through service_stub methods and add a wrapper function to


### PR DESCRIPTION
This patch implements SASL authentication (only GSSAPI was tested). SASL authentication is required for secure clusters, specifically the ones that use Kerberos. In Hadoop SASL is implemented on top of the Hadoop RPC protocol. I have chosen not to refactor any of the code yet, that could be done in a later patch.

* Dependencies on sasl and python-krbV are added