### PR TITLE
Minor fix for doc of client.AutoConfigClient

### DIFF
--- a/snakebite/client.py
+++ b/snakebite/client.py
@@ -1412,10 +1412,12 @@ class HAClient(Client):
 HAClient._wrap_methods()
 
 class AutoConfigClient(HAClient):
-    ''' A pure python HDFS client that support HA and is auto configured through the ``HADOOP_PATH`` environment variable.
+    ''' A pure python HDFS client that support HA and is auto configured through the ``HADOOP_HOME`` environment variable.
 
     HAClient is fully backwards compatible with the vanilla Client and can be used for a non HA cluster as well.
-    This client tries to read ``${HADOOP_PATH}/conf/hdfs-site.xml`` to get the address of the namenode.
+    This client tries to read ``${HADOOP_HOME}/conf/hdfs-site.xml`` and ``${HADOOP_HOME}/conf/core-site.xml``
+    to get the address of the namenode.
+
     The behaviour is the same as Client.
 
     **Example:**


### PR DESCRIPTION
The current documentation states that HADOOP_PATH is used to determine additional
locations of configuration files. Instead HADOOP_HOME (and actually HADOOP_CONF_DIR, but
with this one I'm not sure if its consistently supported) is used. Also, it's worth
mentioning that core-site.xml is required for configuration as well to determine
default file-system name.