### PR TITLE
Wraps use of the Python 'pwd' module in a utility procedure

### DIFF
--- a/snakebite/channel.py
+++ b/snakebite/channel.py
@@ -41,7 +41,6 @@ May 2012
 # Standard library imports
 import socket
 import os
-import pwd
 import math
 
 # Third party imports
@@ -53,6 +52,7 @@ from snakebite.protobuf.IpcConnectionContext_pb2 import IpcConnectionContextProt
 from snakebite.protobuf.ProtobufRpcEngine_pb2 import RequestHeaderProto
 from snakebite.protobuf.datatransfer_pb2 import OpReadBlockProto, BlockOpResponseProto, PacketHeaderProto, ClientReadStatusProto
 
+from snakebite.platformutils import get_current_username
 from snakebite.formatter import format_bytes
 from snakebite.errors import RequestError
 from snakebite.crc32c import crc
@@ -181,7 +181,7 @@ class SocketRpcChannel(RpcChannel):
             kerberos = Kerberos()
             self.effective_user = effective_user or kerberos.user_principal().name
         else: 
-            self.effective_user = effective_user or pwd.getpwuid(os.getuid())[0]
+            self.effective_user = effective_user or get_current_username()
 
     def validate_request(self, request):
         '''Validate the client request against the protocol file.'''

--- a/snakebite/client.py
+++ b/snakebite/client.py
@@ -15,6 +15,7 @@
 
 import snakebite.protobuf.ClientNamenodeProtocol_pb2 as client_proto
 import snakebite.glob as glob
+from snakebite.platformutils import get_current_username
 from snakebite.channel import DataXceiverChannel
 from snakebite.config import HDFSConfig
 from snakebite.errors import (
@@ -36,7 +37,6 @@ import bz2
 import logging
 import os
 import os.path
-import pwd
 import fnmatch
 import inspect
 import socket
@@ -1176,7 +1176,7 @@ class Client(object):
         '''
 
         if not paths:
-            paths = [os.path.join("/user", pwd.getpwuid(os.getuid())[0])]
+            paths = [os.path.join("/user", get_current_username())]
 
         # Expand paths if necessary (/foo/{bar,baz} --> ['/foo/bar', '/foo/baz'])
         paths = glob.expand_paths(paths)
@@ -1326,10 +1326,10 @@ class Client(object):
         return self.service.getFileInfo(request)
 
     def _join_user_path(self, path):
-        return os.path.join("/user", pwd.getpwuid(os.getuid())[0], path)
+        return os.path.join("/user", get_current_username(), path)
 
     def _remove_user_path(self, path):
-        dir_to_remove = os.path.join("/user", pwd.getpwuid(os.getuid())[0])
+        dir_to_remove = os.path.join("/user", get_current_username())
         return path.replace(dir_to_remove+'/', "", 1)
 
     def _normalize_path(self, path):

--- a/snakebite/commandlineparser.py
+++ b/snakebite/commandlineparser.py
@@ -17,7 +17,6 @@ import argparse
 import errno
 import sys
 import os
-import pwd
 import json
 from urlparse import urlparse
 
@@ -35,6 +34,7 @@ from snakebite.formatter import format_du
 from snakebite.config import HDFSConfig
 from snakebite.version import version
 from snakebite.namenode import Namenode
+from snakebite.platformutils import get_current_username
 
 
 def print_error_exit(msg, fd=sys.stderr):
@@ -194,7 +194,7 @@ class CommandLineParser(object):
                     self.parser.add_argument(opt_data['short'], opt_data['long'], help=opt_data['help'], type=opt_data['type'])
 
     def _add_subparsers(self):
-        default_dir = os.path.join("/user", pwd.getpwuid(os.getuid())[0])
+        default_dir = os.path.join("/user", get_current_username())
 
         #sub-options
         arg_parsers = {}

--- a/snakebite/platformutils.py
+++ b/snakebite/platformutils.py
@@ -1,0 +1,13 @@
+import os
+import platform
+
+if platform.system() != "Windows":
+    import pwd
+else:
+    import getpass
+
+def get_current_username():
+    if platform.system() != "Windows":
+        return pwd.getpwuid(os.getuid())[0]
+    else:
+        return getpass.getuser()

--- a/test/commandlineparser_test.py
+++ b/test/commandlineparser_test.py
@@ -14,7 +14,6 @@
 # the License.
 import unittest2
 import os
-import pwd
 import json
 import sys
 import traceback
@@ -24,6 +23,7 @@ from mock import MagicMock, patch, mock_open
 from snakebite.config import HDFSConfig
 from snakebite.commandlineparser import Commands, CommandLineParser
 from snakebite.namenode import Namenode
+from snakebite.platformutils import get_current_username
 
 from config_test import ConfigTest
 
@@ -31,7 +31,7 @@ class CommandLineParserTest(unittest2.TestCase):
 
     def setUp(self):
         self.parser = CommandLineParser()
-        self.default_dir = os.path.join("/user", pwd.getpwuid(os.getuid())[0])
+        self.default_dir = os.path.join("/user", get_current_username())
 
     def test_general_options(self):
         parser = self.parser
@@ -660,7 +660,7 @@ class MockParseArgs(object):
 class CommandLineParserInternalConfigTest(unittest2.TestCase):
     def setUp(self):
         self.parser = CommandLineParser()
-        self.default_dir = os.path.join("/user", pwd.getpwuid(os.getuid())[0])
+        self.default_dir = os.path.join("/user", get_current_username())
 
 
     def assert_namenode_spec(self, host, port, version=None):

--- a/test/delete_test.py
+++ b/test/delete_test.py
@@ -14,9 +14,9 @@
 # the License.
 from snakebite.errors import FileNotFoundException
 from snakebite.errors import InvalidInputException
+from snakebite.platformutils import get_current_username
 from minicluster_testbase import MiniClusterTestBase
 
-import pwd
 import os
 import re
 
@@ -59,7 +59,7 @@ class DeleteWithTrashTest(MiniClusterTestBase):
     def setUp(self):
         super(DeleteWithTrashTest, self).setUp()
         self.client.use_trash = True
-        self.username = pwd.getpwuid(os.getuid())[0]
+        self.username = get_current_username()
         self.trash_location = "/user/%s/.Trash/Current" % self.username
 
     def assertNotExists(self, location_under_test):


### PR DESCRIPTION
allowing the library to be imported on Windows. Fixes #162

Note that this is probably not the only Windows-compatibility problem. I will file more issues and submit more pull requests as I discover problems.