### PR TITLE
Adding user as a config option (.snakebiterc)

### DIFF
--- a/snakebite/commandlineparser.py
+++ b/snakebite/commandlineparser.py
@@ -180,6 +180,7 @@ class CommandLineParser(object):
         self._build_parent_parser()
         self._add_subparsers()
         self.namenodes = []
+        self.user = None
         self.use_sasl = False
 
     def _build_parent_parser(self):
@@ -346,6 +347,8 @@ class CommandLineParser(object):
                 if self.__usetrash_unset():
                     # commandline setting has higher priority
                     self.args.usetrash = configs.get("use_trash", self.configs['use_trash'])
+
+                self.user = configs.get("user")
             else:
                 # config is a single namenode - no HA
                 self.namenodes.append(Namenode(configs['namenode'],
@@ -440,7 +443,7 @@ class CommandLineParser(object):
             use_trash = self.args.usetrash and not self.args.skiptrash
         else:
             use_trash = self.args.usetrash
-        self.client = HAClient(self.namenodes, use_trash, None, self.use_sasl, self.configs['hdfs_namenode_principal'])
+        self.client = HAClient(self.namenodes, use_trash, self.user, self.use_sasl, self.configs['hdfs_namenode_principal'])
 
     def execute(self):
         if self.args.help:

--- a/test/commandlineparser_test.py
+++ b/test/commandlineparser_test.py
@@ -995,6 +995,30 @@ class CommandLineParserInternalConfigTest(unittest2.TestCase):
             self.assert_namenodes_spec("foobar5", 54310, Namenode.DEFAULT_VERSION)
 
 
+    valid_user_rc_v2 = {
+        "config_version": 2,
+        "use_trash": True,
+        "user": "hdfs_user",
+        "namenodes": [
+            {"host": "foobar4", "version": 100},
+            {"host": "foobar5", "port": 54310}
+        ]
+    }
+
+    @patch("os.path.exists")
+    def test_read_config_snakebiterc_user_valid_v2(self, exists_mock):
+        m = mock_open(read_data=json.dumps(self.valid_user_rc_v2))
+
+        with patch("snakebite.commandlineparser.open", m, create=True):
+            self.parser.args = MockParseArgs()
+            self.parser.read_config()
+            self.parser.setup_client()
+            self.assertTrue(self.parser.args.usetrash)
+            self.assertEquals(self.parser.client.effective_user, "hdfs_user")
+            self.assert_namenodes_spec("foobar4", Namenode.DEFAULT_PORT, 100)
+            self.assert_namenodes_spec("foobar5", 54310, Namenode.DEFAULT_VERSION)
+
+
     def test_cl_default_port(self):
         self.parser.args = MockParseArgs(dir=["hdfs://foobar/user/rav"],
                                          single_arg="hdfs://foobar/user/rav",


### PR DESCRIPTION
For when your remote hdfs user is not the same as your local user.

The API was already there, I just passed 'user' along in the config.