### PR TITLE
Make kerberos optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,14 @@ To install snakebite 2.x run:
 
   pip install snakebite
 
+
+
+To install snakebite 2.x with Kerberos/SASL support, make sure you can install python-krbV (https://fedorahosted.org/python-krbV/) and then run:
+
+  pip install "snakebite[kerberos]"
+
+
+
 Documentation
 *************
 More information and documentation can be found at http://spotify.github.io/snakebite/

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+snakebite (2.7.0) unstable; urgency=low
+
+   * Make kerberos/sasl optional in python packaging
+
+ -- Wouter de Bie <wouter@spotify.com>  Tue, 24 Sep 2015 13:12:25 -0000
+
 snakebite (2.6.1) unstable; urgency=low
 
    * Wraps use of the Python 'pwd' module in a utility procedure for Windows compatibility

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 argparse
 protobuf>2.4.1
-sasl
-python-krbV

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,13 @@ class Tox(TestCommand):
 
 install_requires = [
     'protobuf>2.4.1',
-    'argparse',
-    'sasl',
-    'python-krbV']
+    'argparse']
+
+extras_require = {
+    'kerberos': [
+        'python-krbV',
+        'sasl']
+}
 
 tests_require = [
     'tox',
@@ -74,6 +78,7 @@ setup(
         ('', ['LICENSE'])
     ],
     install_requires=install_requires,
+    extras_require=extras_require,
     tests_require=tests_require,
     cmdclass={'test': Tox}
 )

--- a/snakebite/channel.py
+++ b/snakebite/channel.py
@@ -60,10 +60,6 @@ from snakebite.crc32c import crc
 import google.protobuf.internal.encoder as encoder
 import google.protobuf.internal.decoder as decoder
 
-# SASL
-from snakebite.rpc_sasl import SaslRpcClient
-from snakebite.kerberos import Kerberos
-
 # Module imports
 
 import logger
@@ -178,6 +174,13 @@ class SocketRpcChannel(RpcChannel):
         self.client_id = str(uuid.uuid4())
         self.use_sasl = use_sasl
         if self.use_sasl:
+            try:
+                # Only import if SASL is enabled
+                from snakebite.rpc_sasl import SaslRpcClient
+                from snakebite.kerberos import Kerberos
+            except ImportError:
+                raise Exception("Kerberos libs not found. Please install snakebite using 'pip install snakebite[kerberos]'")
+
             kerberos = Kerberos()
             self.effective_user = effective_user or kerberos.user_principal().name
         else: 

--- a/snakebite/version.py
+++ b/snakebite/version.py
@@ -1,4 +1,4 @@
-VERSION = "2.6.1"
+VERSION = "2.7.0"
 
 
 def version():


### PR DESCRIPTION
There are issues with building snakebite since the dependency is on python-krbV, which in it's turn needs the header files for kerberos. This makes kerberos support optional and installable through `pip install "snakebite[kerberos]"`