### PR TITLE
Update rpc_sasl.py

### DIFF
--- a/snakebite/rpc_sasl.py
+++ b/snakebite/rpc_sasl.py
@@ -105,6 +105,8 @@ class SaslRpcClient:
             s_mechs = str(",".join(mechs))
             ret, chosen_mech, initial_response = self.sasl.start(s_mechs)
             log.debug("Chosen mech: %s" % chosen_mech)
+            if not ret:
+                raise Exception("Sasl failed to start: %s" % self.sasl.getError())
 
             initiate = RpcSaslProto()
             initiate.state = 2


### PR DESCRIPTION
Throw an error if SASL failed to start. This way, a useful error message is printed rather than a generic failure later in the program. This helped debug configuration issues.