### PR TITLE
Common base class for exceptions; differentiating transient and fatal exceptions

### DIFF
--- a/snakebite/errors.py
+++ b/snakebite/errors.py
@@ -14,41 +14,65 @@
 # the License.
 
 
-class ConnectionFailureException(Exception):
+class SnakebiteException(Exception):
+    """
+    Common base class for all snakebite exceptions.
+    """
+    pass
+
+
+class FatalException(SnakebiteException):
+    """
+    FatalException indicates that retry of current operation alone would have the same effect.
+    """
+    pass
+
+
+class TransientException(SnakebiteException):
+    """
+    TransientException indicates that retry of current operation could help.
+    """
+    pass
+
+
+class ConnectionFailureException(TransientException):
     def __init__(self, msg):
         super(ConnectionFailureException, self).__init__(msg)
 
 
-class DirectoryException(Exception):
+class DirectoryException(FatalException):
     def __init__(self, msg):
         super(DirectoryException, self).__init__(msg)
 
 
-class FileAlreadyExistsException(Exception):
+class FileAlreadyExistsException(FatalException):
     def __init__(self, msg):
         super(FileAlreadyExistsException, self).__init__(msg)
 
 
-class FileException(Exception):
+class FileException(FatalException):
     def __init__(self, msg):
         super(FileException, self).__init__(msg)
 
 
-class FileNotFoundException(Exception):
+class FileNotFoundException(FatalException):
     def __init__(self, msg):
         super(FileNotFoundException, self).__init__(msg)
 
 
-class InvalidInputException(Exception):
+class InvalidInputException(FatalException):
     def __init__(self, msg):
         super(InvalidInputException, self).__init__(msg)
 
 
-class OutOfNNException(Exception):
+class OutOfNNException(TransientException):
     def __init__(self, msg):
         super(OutOfNNException, self).__init__(msg)
 
 
-class RequestError(Exception):
+class RequestError(TransientException):
+    """
+    Note: request error could be transient and could be fatal, depending on underlying error.
+    """
     def __init__(self, msg):
         super(RequestError, self).__init__(msg)

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -7,7 +7,8 @@ from mock import patch, Mock
 from snakebite.client import HAClient, AutoConfigClient, Client
 from snakebite.config import HDFSConfig
 from snakebite.namenode import Namenode
-from snakebite.errors import OutOfNNException, RequestError
+from snakebite.errors import OutOfNNException, RequestError, InvalidInputException
+
 
 class ClientTest(unittest2.TestCase):
     original_hdfs_try_path = set(HDFSConfig.hdfs_try_paths)
@@ -61,7 +62,7 @@ class ClientTest(unittest2.TestCase):
 
     def test_empty_namenodes_haclient(self):
         namenodes = ()
-        self.assertRaises(OutOfNNException, HAClient, namenodes)
+        self.assertRaises(InvalidInputException, HAClient, namenodes)
 
     @patch('os.environ.get')
     def test_empty_namenodes_autoclient(self, environ_get):


### PR DESCRIPTION
First of all its useful to differentiate snakebite exceptions from other using common base class - so all snakebite exceptions could be caught without need to support error-prone list of exception classes in user code.
Secondly, its helpful to differentiate transient errors (e.g. network-related problems), so user code could apply custom retry policy instead of failing entire peace of work altogether.
I have to confess I was't sure about SASL code, so exceptions in rpc_sasl.py left unchanged.
And I should note that differentiating exceptions has to be done in new and edited code on a constant basis for it to work.