### PR TITLE
Use InvalidInputException instead of OutOfNNException.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Development
 ===========
 
 Make sure to read about development
-[here](http://spotify.github.io/snakebite/development.html) and about
-testing over [here](http://spotify.github.io/snakebite/testing.html),
+[here](http://snakebite.readthedocs.org/en/latest/development.html) and about
+testing over [here](http://snakebite.readthedocs.org/en/latest/testing.html),
 hack and come back with a pull requests &lt;3
 
 Travis CI status: [![Travis](https://api.travis-ci.org/spotify/snakebite.png)](https://travis-ci.org/spotify/snakebite)

--- a/snakebite/client.py
+++ b/snakebite/client.py
@@ -1496,5 +1496,5 @@ class AutoConfigClient(HAClient):
         configs = HDFSConfig.get_external_config()
         nns = [Namenode(nn['namenode'], nn['port'], hadoop_version) for nn in configs['namenodes']]
         if not nns:
-            raise OutOfNNException("Tried and failed to find namenodes - couldn't created the client!")
+            raise InvalidInputException("List of namenodes is empty - couldn't create the client")
         super(AutoConfigClient, self).__init__(nns, configs.get('use_trash', False), effective_user, configs.get('use_sasl', False), configs.get('hdfs_namenode_principal', None))

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -70,4 +70,4 @@ class ClientTest(unittest2.TestCase):
         environ_get.return_value = False
         HDFSConfig.hdfs_try_paths = ()
         HDFSConfig.core_try_paths = ()
-        self.assertRaises(OutOfNNException, AutoConfigClient)
+        self.assertRaises(InvalidInputException, AutoConfigClient)


### PR DESCRIPTION
https://github.com/spotify/snakebite/pull/189 differentiated transient and fatal exceptions. In [this case](https://github.com/spotify/snakebite/pull/189/files#diff-d9827893b8ca9a0f86a685a5fd2327b5L1383) `OutOfNNException` was replaced with `InvalidInputException` to conform to this new distinction. The similar case in the child constructor was probably forgotten to be changed and this PR fixes it up.

The only remaining question is whether `InvalidInputException` is still appropriate, or:
1) A new `InvalidConfigException` should be introduced
2) The more general `FatalException` should be used