### PR TITLE
Increase client robusteness by adding retry and request timeout

### DIFF
--- a/snakebite/client.py
+++ b/snakebite/client.py
@@ -45,6 +45,7 @@ import errno
 import time
 import re
 import sys
+import random
 
 if sys.version_info[0] == 3:
     long = int
@@ -85,7 +86,9 @@ class Client(object):
         3: "s"
     }
 
-    def __init__(self, host, port=Namenode.DEFAULT_PORT, hadoop_version=Namenode.DEFAULT_VERSION, use_trash=False, effective_user=None, use_sasl=False, hdfs_namenode_principal=None):
+    def __init__(self, host, port=Namenode.DEFAULT_PORT, hadoop_version=Namenode.DEFAULT_VERSION,
+                 use_trash=False, effective_user=None, use_sasl=False, hdfs_namenode_principal=None,
+                 sock_connect_timeout=10000, sock_request_timeout=10000):
         '''
         :param host: Hostname or IP address of the NameNode
         :type host: string
@@ -101,6 +104,10 @@ class Client(object):
         :type use_sasl: boolean
         :param hdfs_namenode_principal: Kerberos principal to use for HDFS
         :type hdfs_namenode_principal: string
+        :param sock_connect_timeout: Socket connection timeout in seconds
+        :type sock_connect_timeout: int
+        :param sock_request_timeout: Request timeout in seconds
+        :type sock_request_timeout: int
         '''
         if hadoop_version < 9:
             raise FatalException("Only protocol versions >= 9 supported")
@@ -110,7 +117,9 @@ class Client(object):
         self.use_sasl = use_sasl
         self.hdfs_namenode_principal = hdfs_namenode_principal
         self.service_stub_class = client_proto.ClientNamenodeProtocol_Stub
-        self.service = RpcService(self.service_stub_class, self.port, self.host, hadoop_version, effective_user, self.use_sasl, self.hdfs_namenode_principal)
+        self.service = RpcService(self.service_stub_class, self.port, self.host, hadoop_version,
+                                  effective_user,self.use_sasl, self.hdfs_namenode_principal,
+                                  sock_connect_timeout, sock_request_timeout)
         self.use_trash = use_trash
         self.trash = self._join_user_path(".Trash")
         self._server_defaults = None
@@ -1369,7 +1378,14 @@ class HAClient(Client):
                 else:
                     setattr(cls, name, cls._ha_return_method(meth))
 
-    def __init__(self, namenodes, use_trash=False, effective_user=None, use_sasl=False, hdfs_namenode_principal=None):
+    def _reset_retries(self):
+        log.debug("Resetting retries and failovers")
+        self.failovers = 0
+        self.retries = 0
+
+    def __init__(self, namenodes, use_trash=False, effective_user=None, use_sasl=False, hdfs_namenode_principal=None,
+                 max_failovers=15, max_retries=10, base_sleep=500, max_sleep=15000, sock_connect_timeout=10000,
+                 sock_request_timeout=10000):
         '''
         :param namenodes: Set of namenodes for HA setup
         :type namenodes: list
@@ -1381,11 +1397,32 @@ class HAClient(Client):
         :type use_sasl: boolean
         :param hdfs_namenode_principal: Kerberos principal to use for HDFS
         :type hdfs_namenode_principal: string
+        :param max_retries: Number of failovers in case of connection issues
+        :type max_retries: int
+        :param max_retries: Max number of retries for failures
+        :type max_retries: int
+        :param base_sleep: Base sleep time for retries in milliseconds
+        :type base_sleep: int
+        :param max_sleep: Max sleep time for retries in milliseconds
+        :type max_sleep: int
+        :param sock_connect_timeout: Socket connection timeout in seconds
+        :type sock_connect_timeout: int
+        :param sock_request_timeout: Request timeout in seconds
+        :type sock_request_timeout: int
         '''
         self.use_trash = use_trash
         self.effective_user = effective_user
         self.use_sasl = use_sasl
         self.hdfs_namenode_principal = hdfs_namenode_principal
+        self.max_failovers = max_failovers
+        self.max_retries = max_retries
+        self.base_sleep = base_sleep
+        self.max_sleep = max_sleep
+        self.sock_connect_timeout = sock_connect_timeout
+        self.sock_request_timeout = sock_request_timeout
+
+        self.failovers = -1
+        self.retries = -1
 
         if not namenodes:
             # Using InvalidInputException instead of OutOfNNException because the later is transient but current case
@@ -1394,49 +1431,87 @@ class HAClient(Client):
         self.namenode = self._switch_namenode(namenodes)
         self.namenode.next()
 
-    def _switch_namenode(self, namenodes):
-        for namenode in namenodes:
-            log.debug("Switch to namenode: %s:%d" % (namenode.host, namenode.port))
-
-            yield super(HAClient, self).__init__(namenode.host,
-                                                 namenode.port,
-                                                 namenode.version,
-                                                 self.use_trash,
-                                                 self.effective_user,
-                                                 self.use_sasl,
-                                                 self.hdfs_namenode_principal)
-        else:
-            msg = "Request tried and failed for all %d namenodes: " % len(namenodes)
+    def _check_failover(self, namenodes):
+        if (self.failovers == -1):
+            return
+        elif (self.failovers >= self.max_failovers):
+            msg = "Request tried and failed for all %d namenodes after %d failovers: " % (len(namenodes), self.failovers)
             for namenode in namenodes:
                 msg += "\n\t* %s:%d" % (namenode.host, namenode.port)
             msg += "\nLook into debug messages - add -D flag!"
+            log.debug(msg)
             raise OutOfNNException(msg)
+        log.debug("Failover attempt %d:", self.failovers)
+        self.__do_retry_sleep(self.failovers)
+        self.failovers += 1
+
+    def _switch_namenode(self, namenodes):
+        while (True):
+            for namenode in namenodes:
+                self._check_failover(namenodes)
+                log.debug("Switch to namenode: %s:%d" % (namenode.host, namenode.port))
+                yield super(HAClient, self).__init__(namenode.host,
+                                                     namenode.port,
+                                                     namenode.version,
+                                                     self.use_trash,
+                                                     self.effective_user,
+                                                     self.use_sasl,
+                                                     self.hdfs_namenode_principal,
+                                                     self.sock_connect_timeout,
+                                                     self.sock_request_timeout)
+
+
+    def __calculate_exponential_time(self, time, retries, cap):
+        # Same calculation as the original Hadoop client but converted to seconds
+        baseTime = min(time * (1L << retries), cap);
+        return (baseTime * (random.random() + 0.5)) / 1000;
+
+    def __do_retry_sleep(self, retries):
+        # Don't wait for the first retry.
+        if (retries <= 0):
+            sleep_time = 0
+        else:
+            sleep_time = self.__calculate_exponential_time(self.base_sleep, retries, self.max_sleep)
+        log.debug("Doing retry sleep for %s seconds", sleep_time)
+        time.sleep(sleep_time)
+
+    def __should_retry(self):
+        if self.retries >= self.max_retries:
+            return False
+        else:
+            log.debug("Running retry %d of %d", self.retries, self.max_retries)
+            self.__do_retry_sleep(self.retries)
+            self.retries += 1
+            return True
 
     def __handle_request_error(self, exception):
         log.debug("Request failed with %s" % exception)
         if exception.args[0].startswith("org.apache.hadoop.ipc.StandbyException"):
-            pass
+            self.namenode.next() # Failover and retry until self.max_failovers was reached
+        elif exception.args[0].startswith("org.apache.hadoop.ipc.RetriableException") and self.__should_retry():
+            return
         else:
             # There's a valid NN in active state, but there's still request error - raise
+            # The Java Hadoop client does retry exceptions that are instance of IOException but
+            # not instance of RemoteException here. However some cases have an at most once flag
+            # thus we should not simply retry everything here. Let's fail it for now.
             raise
-        self.namenode.next()
 
     def __handle_socket_error(self, exception):
         log.debug("Request failed with %s" % exception)
         if exception.errno in (errno.ECONNREFUSED, errno.EHOSTUNREACH):
             # if NN is down or machine is not available, pass it:
-            pass
+            self.namenode.next() # Failover and retry until self.max_failovers was reached
         elif isinstance(exception, socket.timeout):
-            # if there's communication/socket timeout, pass it:
-            pass
+            self.namenode.next() # Failover and retry until self.max_failovers was reached
         else:
             raise
-        self.namenode.next()
 
     @staticmethod
     def _ha_return_method(func):
         ''' Method decorator for 'return type' methods '''
         def wrapped(self, *args, **kw):
+            self._reset_retries()
             while(True): # switch between all namenodes
                 try:
                     return func(self, *args, **kw)
@@ -1450,6 +1525,7 @@ class HAClient(Client):
     def _ha_gen_method(func):
         ''' Method decorator for 'generator type' methods '''
         def wrapped(self, *args, **kw):
+            self._reset_retries()
             while(True): # switch between all namenodes
                 try:
                     results = func(self, *args, **kw)
@@ -1497,4 +1573,8 @@ class AutoConfigClient(HAClient):
         nns = [Namenode(nn['namenode'], nn['port'], hadoop_version) for nn in configs['namenodes']]
         if not nns:
             raise InvalidInputException("List of namenodes is empty - couldn't create the client")
-        super(AutoConfigClient, self).__init__(nns, configs.get('use_trash', False), effective_user, configs.get('use_sasl', False), configs.get('hdfs_namenode_principal', None))
+        super(AutoConfigClient, self).__init__(nns, configs.get('use_trash', False), effective_user,
+                                               configs.get('use_sasl', False), configs.get('hdfs_namenode_principal', None),
+                                               configs.get('failover_max_attempts'), configs.get('client_retries'),
+                                               configs.get('client_sleep_base_millis'), configs.get('client_sleep_max_millis'),
+                                               10000, configs.get('socket_timeout_millis'))

--- a/snakebite/commandlineparser.py
+++ b/snakebite/commandlineparser.py
@@ -443,7 +443,10 @@ class CommandLineParser(object):
             use_trash = self.args.usetrash and not self.args.skiptrash
         else:
             use_trash = self.args.usetrash
-        self.client = HAClient(self.namenodes, use_trash, self.user, self.use_sasl, self.configs['hdfs_namenode_principal'])
+        self.client = HAClient(self.namenodes, use_trash, self.user, self.use_sasl, self.configs['hdfs_namenode_principal'],
+                               self.configs['failover_max_attempts'], self.configs['client_retries'],
+                               self.configs['client_sleep_base_millis'], self.configs['client_sleep_max_millis'],
+                               self.configs['socket_timeout_millis'])
 
     def execute(self):
         if self.args.help:

--- a/snakebite/config.py
+++ b/snakebite/config.py
@@ -98,6 +98,21 @@ class HDFSConfig(object):
                 log.debug("hdfs principal found: '%s'" % (property.findall('value')[0].text))
                 configs['hdfs_namenode_principal'] = property.findall('value')[0].text
 
+            if property.findall('name')[0].text == 'dfs.client.retry.max.attempts':
+                configs['client_retries'] = int(property.findall('value')[0].text)
+
+            if property.findall('name')[0].text == 'dfs.client.socket-timeout':
+                configs['socket_timeout_millis'] = int(property.findall('value')[0].text)
+
+            if property.findall('name')[0].text == 'dfs.client.failover.sleep.base.millis':
+                configs['client_sleep_base_millis'] = int(property.findall('value')[0].text)
+
+            if property.findall('name')[0].text == 'dfs.client.failover.sleep.max.millis':
+                configs['client_sleep_max_millis'] = int(property.findall('value')[0].text)
+
+            if property.findall('name')[0].text == 'dfs.client.failover.max.attempts':
+                configs['failover_max_attempts'] = int(property.findall('value')[0].text)
+
         if namenodes:
             configs['namenodes'] = namenodes
 
@@ -141,7 +156,12 @@ class HDFSConfig(object):
             'use_trash': hdfs_configs.get('use_trash', core_configs.get('use_trash', False)),
             'use_sasl': core_configs.get('use_sasl', False),
             'hdfs_namenode_principal': hdfs_configs.get('hdfs_namenode_principal', None),
-            'namenodes': hdfs_configs.get('namenodes', []) or core_configs.get('namenodes', [])
+            'namenodes': hdfs_configs.get('namenodes', []) or core_configs.get('namenodes', []),
+            'client_retries' : hdfs_configs.get('client_retries', 10),
+            'client_sleep_base_millis' : hdfs_configs.get('client_sleep_base_millis', 500),
+            'client_sleep_max_millis' : hdfs_configs.get('client_sleep_max_millis', 15000),
+            'socket_timeout_millis' : hdfs_configs.get('socket_timeout_millis', 60000),
+            'failover_max_attempts' : hdfs_configs.get('failover_max_attempts', 15)
         }
 
         return configs

--- a/snakebite/service.py
+++ b/snakebite/service.py
@@ -18,14 +18,19 @@ import google.protobuf.service as service
 
 
 class RpcService(object):
-
-    def __init__(self, service_stub_class, port, host, hadoop_version, effective_user=None,use_sasl=False, hdfs_namenode_principal=None):
+    def __init__(self, service_stub_class, port, host, hadoop_version, effective_user=None,
+                 use_sasl=False, hdfs_namenode_principal=None, sock_connect_timeout=10000,
+                 sock_request_timeout=10000):
         self.service_stub_class = service_stub_class
         self.port = port
         self.host = host
 
         # Setup the RPC channel
-        self.channel = SocketRpcChannel(host=self.host, port=self.port, version=hadoop_version, effective_user=effective_user, use_sasl=use_sasl, hdfs_namenode_principal=hdfs_namenode_principal)
+        self.channel = SocketRpcChannel(host=self.host, port=self.port, version=hadoop_version,
+                                        effective_user=effective_user, use_sasl=use_sasl,
+                                        hdfs_namenode_principal=hdfs_namenode_principal,
+                                        sock_connect_timeout=sock_connect_timeout,
+                                        sock_request_timeout=sock_request_timeout,)
         self.service = self.service_stub_class(self.channel)
 
         # go through service_stub methods and add a wrapper function to

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -129,3 +129,12 @@ class ConfigTest(unittest2.TestCase):
         HDFSConfig.hdfs_try_paths = (self.get_config_path('ha-noport-hdfs-site.xml'),)
         client = AutoConfigClient()
         self.assertFalse(client.use_trash)
+
+    def test_retry_configs(self):
+        conf_path = self.get_config_path('ha-retry-hdfs-site.xml')
+        config = HDFSConfig.read_hdfs_config(conf_path)
+        self.assertEquals(config['client_retries'], 5)
+        self.assertEquals(config['client_sleep_base_millis'], 400)
+        self.assertEquals(config['client_sleep_max_millis'], 14000)
+        self.assertEquals(config['socket_timeout_millis'], 25000)
+        self.assertEquals(config['failover_max_attempts'], 7)

--- a/test/testconfig/conf/ha-retry-hdfs-site.xml
+++ b/test/testconfig/conf/ha-retry-hdfs-site.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>dfs.client.retry.max.attempts</name>
+    <value>5</value>
+  </property>
+
+  <property>
+    <name>dfs.client.socket-timeout</name>
+    <value>25000</value>
+  </property>
+
+  <property>
+    <name>dfs.client.failover.sleep.base.millis</name>
+    <value>400</value>
+  </property>
+
+  <property>
+    <name>dfs.client.failover.sleep.max.millis</name>
+    <value>14000</value>
+  </property>
+
+  <property>
+    <name>dfs.client.failover.max.attempts</name>
+    <value>7</value>
+  </property>
+</configuration>


### PR DESCRIPTION
Add a request retry logic for connection failures. Use the retry value from the Hadoop configuration if set. This enables the client to not fail in case the NameNode RPC queues are full. The retry logic and its default settings are the same as in the original Java HdfsClient. The calculation of sleep interval was simply ported to Python. Successful requests might be repeated in case of network failures but this is the same in the vanilla Hadoop implementation and the NameNode interfaces are designed to handle this by either being idempotent (see ClientProtocol @Idempotent annotations) or failing upon the second request, e.g. double creations.

Configure the channel socket to use the socket timeout as configured for Hadoop after establishing the connection. This helps to not time out when running slow operations on the NameNode, such as large listings, or when having large and filled up RPC queues.