### PR TITLE
Changing the 'open' command to open a temporary file as binary.

### DIFF
--- a/snakebite/client.py
+++ b/snakebite/client.py
@@ -753,7 +753,7 @@ class Client(object):
         # Source is a file
         elif self._is_file(node):
             temporary_target = "%s._COPYING_" % target
-            f = open(temporary_target, 'w')
+            f = open(temporary_target, 'wb')
             try:
                 for load in self._read_file(path, node, tail_only=False, check_crc=check_crc):
                     f.write(load)


### PR DESCRIPTION
The lack of this parameter causes a bug when using copyToLocal to copy a file from a Linux HDFS cluster to a Windows client box. The file that ends up on Windows isn't byte-identical to the starting file on Linux, due to some end-of-line conversion issue.

BTW: This is literally a one-character change, so I didn't bother to open an issue first. Let me know if you'd prefer to have an issue and I can create one.