### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ Note that the 1.3 branch is unmaintained and doesn't include any of the fixes in
 Documentation
 =============
 
-More information and documentation can be found at http://snakebite.readthedocs.org/en/latest/
+More information and documentation can be found at https://snakebite.readthedocs.io/en/latest/
 
 Development
 ===========
 
 Make sure to read about development
-[here](http://snakebite.readthedocs.org/en/latest/development.html) and about
-testing over [here](http://snakebite.readthedocs.org/en/latest/testing.html),
+[here](https://snakebite.readthedocs.io/en/latest/development.html) and about
+testing over [here](https://snakebite.readthedocs.io/en/latest/testing.html),
 hack and come back with a pull requests &lt;3
 
 Travis CI status: [![Travis](https://api.travis-ci.org/spotify/snakebite.png)](https://travis-ci.org/spotify/snakebite)

--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -14,7 +14,7 @@ environment for snakebite:
 2. create development environment:
 ``$ mkvirtualenv snakebite_dev``
 
-More about virtualenvwrapper and virtualenv `here <http://virtualenvwrapper.readthedocs.org/en/latest/>`_
+More about virtualenvwrapper and virtualenv `here <https://virtualenvwrapper.readthedocs.io/en/latest/>`_
 
 Below is the list of recommended steps to start development:
 

--- a/doc/source/testing.rst
+++ b/doc/source/testing.rst
@@ -9,8 +9,8 @@ tests ``MiniClusterTestBase`` - on setup for such test class minicluster is
 started, when tests are done minicluster is destroyed. There's some
 performance overhead - but it's not a problem (yet).
 
-Snakebite by default uses `nose <https://nose.readthedocs.org/en/latest/>`_
-and `tox <https://tox.readthedocs.org/en/latest/>`_ for testing. Tests
+Snakebite by default uses `nose <https://nose.readthedocs.io/en/latest/>`_
+and `tox <https://tox.readthedocs.io/en/latest/>`_ for testing. Tests
 are integrated with `setup.py`, so to start tests one can simply:
 ``$ python setup.py test``
 
@@ -24,7 +24,7 @@ java needs to be present on the system.
 Tox
 ===
 
-`Tox <https://tox.readthedocs.org/en/latest/>`_ allow us to create automated
+`Tox <https://tox.readthedocs.io/en/latest/>`_ allow us to create automated
 isolated python test environments. It's also a place where we can prepare environment
 for testing - like download hadoop distributions, set environment variables etc.
 Tox configuration is available in ``tox.ini`` file in root directory.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.