### PR TITLE
Add client retry for block read failures

### DIFF
--- a/snakebite/errors.py
+++ b/snakebite/errors.py
@@ -76,3 +76,7 @@ class RequestError(TransientException):
     """
     def __init__(self, msg):
         super(RequestError, self).__init__(msg)
+
+class BlockReadException(TransientException):
+    def __init__(self, msg):
+        super(BlockReadException, self).__init__(msg)

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -7,7 +7,7 @@ from mock import patch, Mock, call
 from snakebite.client import HAClient, AutoConfigClient, Client
 from snakebite.config import HDFSConfig
 from snakebite.namenode import Namenode
-from snakebite.errors import OutOfNNException, RequestError, InvalidInputException
+from snakebite.errors import OutOfNNException, RequestError, InvalidInputException, BlockReadException
 
 
 class ClientTest(unittest2.TestCase):
@@ -142,3 +142,14 @@ class ClientTest(unittest2.TestCase):
         self.assertRaises(RequestError, all, cat_result_gen)
         calls = [call("foo", 8020), call("foo", 8020), call("foo", 8020)]
         get_connection.assert_has_calls(calls)
+
+    @patch('snakebite.service.RpcService.call')
+    def test_ha_client_retry(self, rpc_call):
+        retry_attempts = 3
+        e = BlockReadException("Block read failure")
+        rpc_call.side_effect=e
+        nns = [Namenode("foo"), Namenode("bar")]
+        ha_client = HAClient(nns, max_retries=retry_attempts)
+        cat_result_gen = ha_client.cat(['foobar'])
+        self.assertRaises(BlockReadException, all, cat_result_gen)
+        self.assertEquals(rpc_call.call_count, 1 + retry_attempts)


### PR DESCRIPTION
Currently the client will fail on any block read errors even
though these might be transient failures. This patch enables
the client to retry block read failures to make it more
failure tolerant.