### PR TITLE
Support dfs.client.use.datanode.hostname config property

### DIFF
--- a/snakebite/commandlineparser.py
+++ b/snakebite/commandlineparser.py
@@ -446,7 +446,7 @@ class CommandLineParser(object):
         self.client = HAClient(self.namenodes, use_trash, self.user, self.use_sasl, self.configs['hdfs_namenode_principal'],
                                self.configs['failover_max_attempts'], self.configs['client_retries'],
                                self.configs['client_sleep_base_millis'], self.configs['client_sleep_max_millis'],
-                               self.configs['socket_timeout_millis'])
+                               self.configs['socket_timeout_millis'], use_datanode_hostname=self.configs['use_datanode_hostname'])
 
     def execute(self):
         if self.args.help:

--- a/snakebite/config.py
+++ b/snakebite/config.py
@@ -113,6 +113,9 @@ class HDFSConfig(object):
             if property.findall('name')[0].text == 'dfs.client.failover.max.attempts':
                 configs['failover_max_attempts'] = int(property.findall('value')[0].text)
 
+            if property.findall('name')[0].text == 'dfs.client.use.datanode.hostname':
+                configs['use_datanode_hostname'] = bool(property.findall('value')[0].text)
+
         if namenodes:
             configs['namenodes'] = namenodes
 
@@ -161,7 +164,8 @@ class HDFSConfig(object):
             'client_sleep_base_millis' : hdfs_configs.get('client_sleep_base_millis', 500),
             'client_sleep_max_millis' : hdfs_configs.get('client_sleep_max_millis', 15000),
             'socket_timeout_millis' : hdfs_configs.get('socket_timeout_millis', 60000),
-            'failover_max_attempts' : hdfs_configs.get('failover_max_attempts', 15)
+            'failover_max_attempts' : hdfs_configs.get('failover_max_attempts', 15),
+            'use_datanode_hostname' : hdfs_configs.get('use_datanode_hostname', False)
         }
 
         return configs

--- a/test/commandlineparser_test.py
+++ b/test/commandlineparser_test.py
@@ -1093,6 +1093,20 @@ class CommandLineParserInternalConfigTest(unittest2.TestCase):
         finally:
             self._revert_hdfs_try_paths()
 
+    @patch('os.environ.get')
+    def test_use_datanode_hostname(self, environ_get):
+        environ_get.return_value = False
+        # no snakebiterc
+        # read external config (hdfs-site, core-site)
+        self.parser.args = MockParseArgs()
+        try:
+            HDFSConfig.core_try_paths = (ConfigTest.get_config_path('ha-core-site.xml'),)
+            HDFSConfig.hdfs_try_paths = (ConfigTest.get_config_path('use-datanode-hostname-hdfs-site.xml'),)
+            self.parser.init()
+
+            self.assertTrue(self.parser.client.use_datanode_hostname)
+        finally:
+            self._revert_hdfs_try_paths()
 
 
 class CommandLineParserExecuteTest(unittest2.TestCase):

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -138,3 +138,8 @@ class ConfigTest(unittest2.TestCase):
         self.assertEquals(config['client_sleep_max_millis'], 14000)
         self.assertEquals(config['socket_timeout_millis'], 25000)
         self.assertEquals(config['failover_max_attempts'], 7)
+
+    def test_use_datanode_hostname_configs(self):
+        conf_path = self.get_config_path('use-datanode-hostname-hdfs-site.xml')
+        config = HDFSConfig.read_hdfs_config(conf_path)
+        self.assertTrue(config['use_datanode_hostname'])

--- a/test/testconfig/conf/use-datanode-hostname-hdfs-site.xml
+++ b/test/testconfig/conf/use-datanode-hostname-hdfs-site.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>dfs.client.use.datanode.hostname</name>
+    <value>true</value>
+  </property>
+</configuration>


### PR DESCRIPTION
When reading blocks, client talks to datanode by default using the datanode's
IP address returned by the name node. The problem with this approach is that
the IP address is a private IP within the cluster, so the client won't works if
it is in a different network. This commit updates the config module to support
`dfs.client.use.datanode.hostname` config property, and have the clients to use
this property to determine weather to use the IP address or the hostname to
talk to datanodes.