### PR TITLE
Backporting pull request #210 (Support dfs.client.use.datanode.hostname config property) for v1.3

### DIFF
--- a/snakebite/config.py
+++ b/snakebite/config.py
@@ -11,6 +11,7 @@ log = logging.getLogger(__name__)
 class HDFSConfig(object):
     use_trash = False
     use_sasl = False
+    use_datanode_hostname = False
 
     @classmethod
     def get_config_from_env(cls):
@@ -63,6 +64,9 @@ class HDFSConfig(object):
             if property.findall('name')[0].text == 'fs.trash.interval':
                 cls.use_trash = True
 
+            if property.findall('name')[0].text == 'dfs.client.use.datanode.hostname':
+                cls.use_datanode_hostname = bool(property.findall('value')[0].text)
+
             if property.findall('name')[0].text == 'hadoop.security.authentication':
                 log.debug("Got hadoop.security.authentication '%s'" % (property.findall('value')[0].text))
                 if property.findall('value')[0].text == 'kerberos':
@@ -85,6 +89,9 @@ class HDFSConfig(object):
 
             if property.findall('name')[0].text == 'fs.trash.interval':
                 cls.use_trash = True
+
+            if property.findall('name')[0].text == 'dfs.client.use.datanode.hostname':
+                cls.use_datanode_hostname = bool(property.findall('value')[0].text)
 
         return configs
 


### PR DESCRIPTION
This supports the use-datanode-hostname feature and is also able to read it from hadoop config file.
Implementation is a backport of what was done in master branch (pull request #210 ) while taking into account legacy code limitations.

Tested to work (unfortunately there were no relevant unittests that I could easily extend).
It would be great to merge this and bump version to 1.3.13