### PR TITLE
modify client to retry connnect to datanode

### DIFF
--- a/snakebite/client.py
+++ b/snakebite/client.py
@@ -19,7 +19,6 @@ from snakebite.platformutils import get_current_username
 from snakebite.channel import DataXceiverChannel
 from snakebite.config import HDFSConfig
 from snakebite.errors import (
-    ConnectionFailureException,
     DirectoryException,
     FileAlreadyExistsException,
     FileException,
@@ -1162,10 +1161,11 @@ class Client(object):
                             failed_nodes.append(location.id.storageID)
                         successful_read = False
                 else:
-                    raise ConnectionFailureException(
+                    log.warning(
                         u"Failure to connect to data node at ({}:{})".format(
                             host, port
                             ))
+                    continue
                 if successful_read:
                     break
             if successful_read is False:


### PR DESCRIPTION
For now, client.py just try to connect one of datanode in blocklocation queue.

We should try to connect other datanode when one of them failed instead of throwing exception. 