### PR TITLE
Stop mv on error

### DIFF
--- a/snakebite/commandlineparser.py
+++ b/snakebite/commandlineparser.py
@@ -583,7 +583,7 @@ class CommandLineParser(object):
         paths = self.args.dir
         dst = self.args.single_arg
         result = self.client.rename(paths, dst)
-        for line in format_results(result, json_output=self.args.json):
+        for line in format_results(result, json_output=self.args.json, continue_on_error=False):
             print line
 
     @command(args="[paths]", descr="remove paths", allowed_opts=["R", "S", "T"], req_args=['dir [dirs]'])

--- a/snakebite/formatter.py
+++ b/snakebite/formatter.py
@@ -128,7 +128,7 @@ def _create_dir_listing(nodes, human_readable, recursive, summary):
     return "\n".join(ret)
 
 
-def format_results(results, json_output=False):
+def format_results(results, json_output=False, continue_on_error=True):
     if json_output:
         for result in results:
             yield json.dumps(result)
@@ -141,6 +141,9 @@ def format_results(results, json_output=False):
                     yield "OK: %s" % r.get('path')
             else:
                 yield "ERROR: %s (reason: %s)" % (r.get('path'), r.get('error', ''))
+
+                if not continue_on_error:
+                    break
 
 
 def format_counts(results, json_output=False, human_readable=False):


### PR DESCRIPTION
As in #232, continuing mv after an error can have unexpected bad results. By stopping the mv, we leave it up to the user how to resolve the situation.

Using the same test script as in #232, this stops after the failure trying to move `/tmp/test_trash/a` and does not move `/tmp/test_trash/a/b`.