### PR TITLE
#234 Fix: removing py26-hdp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ branches:
 env:
   - TOX_ENV=py26-cdh
   - TOX_ENV=py27-cdh
-  - TOX_ENV=py26-hdp
   - TOX_ENV=py27-hdp
 install:
   - pip install tox


### PR DESCRIPTION
This interpreter is not found:  `  - TOX_ENV=py26-hdp`

(as mentioned in Issue #234 )
hence removing.