### PR TITLE
Fix SyntaxError: invalid syntax errors

### DIFF
--- a/snakebite/client.py
+++ b/snakebite/client.py
@@ -1469,8 +1469,13 @@ class HAClient(Client):
 
 
     def __calculate_exponential_time(self, time, retries, cap):
-        # Same calculation as the original Hadoop client but converted to seconds
-        baseTime = min(time * (1L << retries), cap);
+        # Python versions less than 3 use the long syntax for long integers
+        # this checks Python version and uses appropriate syntax
+        if sys.version_info[0] <=2:
+            # Same calculation as the original Hadoop client but converted to seconds
+            baseTime = min(time * (long(1) << retries), cap)
+        else:
+            baseTime = min(time * (1 << retries), cap)
         return (baseTime * (random.random() + 0.5)) / 1000;
 
     def __do_retry_sleep(self, retries):


### PR DESCRIPTION
Python 3 removes the long integer type syntax eg 1L because
the int datatype in Python 3 includes both ints and longs.

This commit adds a check for the Python version and uses the
appropriate syntax based on the version in use