### PR TITLE
Improve python3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ branches:
   except:
     - gh-pages
 env:
-  - TOX_ENV=py26-cdh
   - TOX_ENV=py27-cdh
-  - TOX_ENV=py26-hdp
   - TOX_ENV=py27-hdp
 install:
   - pip install tox

--- a/snakebite/client.py
+++ b/snakebite/client.py
@@ -1470,7 +1470,7 @@ class HAClient(Client):
 
     def __calculate_exponential_time(self, time, retries, cap):
         # Same calculation as the original Hadoop client but converted to seconds
-        baseTime = min(time * (1L << retries), cap);
+        baseTime = min(time * (long(1) << retries), cap);
         return (baseTime * (random.random() + 0.5)) / 1000;
 
     def __do_retry_sleep(self, retries):


### PR DESCRIPTION
In python 3 `long` and `int` types have been unified and it is no longer
legal to use the L postfix to declare a long.  As this postfix is used
in snakebite it fails under python 3.  This commit improves python 3
support for some use cases.

It is not intended to make snakebite fully python 3 compatible in any
way but just to remove a common issue.  This changes allows limited
functionality under python 3 which is enough for many use-cases.

----
This is basically a clean version of #203 and a simplification of #239 although maybe the changes to `channel.py` should be considered, but since they do not affect me I've not added them.

The impact on the codebase is minimal and this simple change can make a huge difference to users of python 3.x 

