### PR TITLE
switch to sasl3 package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ install_requires = [
 extras_require = {
     'kerberos': [
         'python-krbV',
-        'sasl']
+        'sasl3']
 }
 
 tests_require = [


### PR DESCRIPTION
switch to sasl3 package which fixes Python 3 compatibility and doesn't have runtime issue on rhel6 platform 

https://pypi.org/project/sasl3/